### PR TITLE
Don't use generation number to delete children hierachy

### DIFF
--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
@@ -147,7 +147,7 @@ class MysqlStorage(name: String, host: String, database: String, username: Strin
       "`ts` bigint(20) NOT NULL AUTO_INCREMENT, " +
       "`tk` bigint(20) NOT NULL, "
 
-    sql += ((for (i <- 1 to table.depth) yield " k%d varchar(128) NOT NULL ".format(i)) ++ (for (i <- 1 to table.depth) yield " g%d varchar(128) NOT NULL ".format(i))).mkString(",") + ","
+    sql += (for (i <- 1 to table.depth) yield " k%d varchar(128) NOT NULL ".format(i)).mkString(",") + ","
 
     val keyList = (for (i <- 1 to table.depth) yield "k%d".format(i)).mkString(",")
     sql += " `d` blob NULL, " +
@@ -295,7 +295,7 @@ class MysqlStorage(name: String, host: String, database: String, username: Strin
             var collectedVersions = 0
             while (versions.size > 0 && collectedVersions < collectPerTable) {
               val version = versions.dequeue()
-              val toDeleteCount = (version.generations - table.maxVersions)
+              val toDeleteCount = (version.versionsCount - table.maxVersions)
 
               trx.truncateVersions(table, version.token, version.accessPath, toDeleteCount)
 

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/RecordValue.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/RecordValue.scala
@@ -24,9 +24,6 @@ class RecordValue(storage: MysqlStorage, context: ExecutionContext, table: Table
   val innerValue = {
     this.optRecord match {
       case Some(r) =>
-        // update generation
-        accessPath.last.generation = r.accessPath.last.generation
-
         r.value
       case None =>
         new NullValue

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableValue.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableValue.scala
@@ -43,9 +43,6 @@ class TableValue(storage: MysqlStorage, table: Table, accessPrefix: AccessPath =
     if (!context.dryMode) {
       val transaction = context.getStorageTransaction(storage).asInstanceOf[MysqlTransaction]
 
-      // get current value to get generation to use
-      accessPath.last.generation = Some(this.getGeneration(transaction, token, context.timestamp, accessPath))
-
       val record = new Record
       record.value = mapVal
       transaction.set(table, token, context.timestamp, accessPath, Some(record))
@@ -63,22 +60,7 @@ class TableValue(storage: MysqlStorage, table: Table, accessPrefix: AccessPath =
     if (!context.dryMode) {
       val transaction = context.getStorageTransaction(storage).asInstanceOf[MysqlTransaction]
 
-      // get current value to get generation to use
-      accessPath.last.generation = Some(this.getGeneration(transaction, token, context.timestamp, accessPath))
-
       transaction.set(table, token, context.timestamp, accessPath, None)
-    }
-  }
-
-  private def getGeneration(transaction:MysqlTransaction, token:Long, timestamp:Timestamp, accessPath:AccessPath):Int = {
-    val curRec = transaction.get(table, token, timestamp, accessPath, includeDeleted = true)
-    if (curRec.isDefined) {
-      if (!curRec.get.value.isNull)
-        curRec.get.accessPath.last.generation.get
-      else
-        curRec.get.accessPath.last.generation.get + 1
-    } else {
-      1
     }
   }
 


### PR DESCRIPTION
Don't use generation number to delete children hierarchy, generate tombstone records instead so that percolation on these tables still work. Added test to make sure percolation on children records works when deleting parent records. 

ALTER TABLE `emails` DROP COLUMN `g1` ;
ALTER TABLE `followees` DROP COLUMN `g1` ;
ALTER TABLE `followees_followers` DROP COLUMN `g2` , DROP COLUMN `g1` ;
ALTER TABLE `installs` DROP COLUMN `g1` ;
ALTER TABLE `networks` DROP COLUMN `g1` ;
ALTER TABLE `networks_followees` DROP COLUMN `g2` , DROP COLUMN `g1` ;
ALTER TABLE `networks_users` DROP COLUMN `g2` , DROP COLUMN `g1` ;
ALTER TABLE `users` DROP COLUMN `g1` ;
ALTER TABLE `users_networks` DROP COLUMN `g2` , DROP COLUMN `g1` ;
ALTER TABLE `users_networks_followees` DROP COLUMN `g3` , DROP COLUMN `g2` , DROP COLUMN `g1` ;
