### PR TITLE
Fetch MRY timestamp from new ConsistencyMasterSlave (READ DISCLAIMER)

### DIFF
--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlBase.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlBase.scala
@@ -3,8 +3,8 @@ package com.wajam.mry.storage.mysql
 import com.wajam.mry.execution._
 import com.wajam.mry.storage.Storage
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
-import com.wajam.scn.Timestamp
 import com.wajam.scn.storage.ScnTimestamp
+import com.wajam.nrv.utils.timestamp.Timestamp
 
 
 abstract class TestMysqlBase extends FunSuite with BeforeAndAfterEach {

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlBase.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlBase.scala
@@ -4,6 +4,7 @@ import com.wajam.mry.execution._
 import com.wajam.mry.storage.Storage
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import com.wajam.scn.Timestamp
+import com.wajam.scn.storage.ScnTimestamp
 
 
 abstract class TestMysqlBase extends FunSuite with BeforeAndAfterEach {
@@ -38,7 +39,7 @@ abstract class TestMysqlBase extends FunSuite with BeforeAndAfterEach {
     mysqlStorage.stop()
   }
 
-  def exec(cb: (Transaction => Unit), commit: Boolean = true, onTimestamp: Timestamp = Timestamp.now): Seq[Value] = {
+  def exec(cb: (Transaction => Unit), commit: Boolean = true, onTimestamp: Timestamp = createNowTimestamp()): Seq[Value] = {
     val context = new ExecutionContext(storages, Some(onTimestamp))
 
     try {
@@ -56,7 +57,9 @@ abstract class TestMysqlBase extends FunSuite with BeforeAndAfterEach {
   }
 
   def createTimestamp(time: Long) = new Timestamp {
-    def value = time
+    val value = time
   }
+
+  def createNowTimestamp() = createTimestamp(System.currentTimeMillis() * 10000)
 
 }

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlBase.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlBase.scala
@@ -3,7 +3,6 @@ package com.wajam.mry.storage.mysql
 import com.wajam.mry.execution._
 import com.wajam.mry.storage.Storage
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
-import com.wajam.scn.storage.ScnTimestamp
 import com.wajam.nrv.utils.timestamp.Timestamp
 
 

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -10,6 +10,7 @@ import util.Random
 import com.wajam.scn.Timestamp
 import org.scalatest.matchers.ShouldMatchers._
 import com.wajam.mry.storage.mysql.TimelineSelectMode.AtTimestamp
+import com.wajam.scn.storage.ScnTimestamp
 
 /**
  * Test MySQL storage
@@ -255,17 +256,17 @@ class TestMysqlStorage extends TestMysqlBase {
     val transac = new MysqlTransaction(mysqlStorage, None)
     val initRec = new Record(Map("test" -> 1234))
     val path = new AccessPath(Seq(new AccessKey("test1")))
-    transac.set(table1, 1, Timestamp.now, path, Some(initRec))
+    transac.set(table1, 1, createNowTimestamp(), path, Some(initRec))
 
-    val rec1 = transac.get(table1, 1, Timestamp.now, path)
+    val rec1 = transac.get(table1, 1, createNowTimestamp(), path)
     assert(rec1.get.value.asInstanceOf[MapValue]("test").equalsValue(1234))
 
-    transac.set(table1, 1, Timestamp.now, path, None)
+    transac.set(table1, 1, createNowTimestamp(), path, None)
 
-    val rec2 = transac.get(table1, 1, Timestamp.now, path)
+    val rec2 = transac.get(table1, 1, createNowTimestamp(), path)
     assert(rec2.isEmpty)
 
-    val rec3 = transac.get(table1, 1, Timestamp.now, path, includeDeleted = true)
+    val rec3 = transac.get(table1, 1, createNowTimestamp(), path, includeDeleted = true)
     assert(rec3.isDefined)
     assert(rec3.get.value.isNull)
 
@@ -319,7 +320,6 @@ class TestMysqlStorage extends TestMysqlBase {
   }
 
   test("operations should be kept in a history") {
-    val fromTimestamp = Timestamp.now
     exec(t => {
       val storage = t.from("mysql")
       val table = storage.from("table1")

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -7,10 +7,10 @@ import com.wajam.mry.execution._
 import com.wajam.mry.storage.StorageException
 import collection.mutable
 import util.Random
-import com.wajam.scn.Timestamp
 import org.scalatest.matchers.ShouldMatchers._
 import com.wajam.mry.storage.mysql.TimelineSelectMode.AtTimestamp
 import com.wajam.scn.storage.ScnTimestamp
+import com.wajam.nrv.utils.timestamp.Timestamp
 
 /**
  * Test MySQL storage

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -9,8 +9,6 @@ import collection.mutable
 import util.Random
 import org.scalatest.matchers.ShouldMatchers._
 import com.wajam.mry.storage.mysql.TimelineSelectMode.AtTimestamp
-import com.wajam.scn.storage.ScnTimestamp
-import com.wajam.nrv.utils.timestamp.Timestamp
 
 /**
  * Test MySQL storage

--- a/mry-core/src/main/scala/com/wajam/mry/Database.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/Database.scala
@@ -5,18 +5,17 @@ import storage.Storage
 import com.wajam.nrv.Logging
 import com.yammer.metrics.scala.Instrumented
 import com.wajam.nrv.service.{ActionMethod, Resolver, Action, Service}
-import com.wajam.scn.client.ScnClient
-import com.wajam.scn.Timestamp
 import com.wajam.nrv.tracing.Traced
 import java.util.concurrent.atomic.AtomicReference
 import com.wajam.nrv.data.InMessage
 import com.wajam.nrv.utils.{Promise, Future}
+import com.wajam.nrv.utils.timestamp.{TimestampGenerator, Timestamp}
 
 
 /**
  * MRY database
  */
-class Database(var serviceName: String = "database", val scn: ScnClient)
+class Database(var serviceName: String = "database", val timestampGenerator: TimestampGenerator)
   extends Service(serviceName) with Logging with Instrumented with Traced {
 
   var storages = Map[String, Storage]()
@@ -116,7 +115,7 @@ class Database(var serviceName: String = "database", val scn: ScnClient)
 
   private def fetchTimestampAndExecute(req: InMessage) {
     val timerContext = this.metricExecuteLocal.timerContext()
-    scn.fetchTimestamps(serviceName, (timestamps: Seq[Timestamp], optException) => {
+    timestampGenerator.fetchTimestamps(serviceName, (timestamps: Seq[Timestamp], optException) => {
       try {
         if (optException.isDefined) {
           info("Exception while fetching timestamps from SCN.", optException.get)

--- a/mry-core/src/main/scala/com/wajam/mry/Database.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/Database.scala
@@ -6,22 +6,18 @@ import com.wajam.nrv.Logging
 import com.yammer.metrics.scala.Instrumented
 import com.wajam.nrv.service.{ActionMethod, Resolver, Action, Service}
 import com.wajam.nrv.tracing.Traced
-import java.util.concurrent.atomic.AtomicReference
 import com.wajam.nrv.data.InMessage
 import com.wajam.nrv.utils.{Promise, Future}
-import com.wajam.nrv.utils.timestamp.{TimestampGenerator, Timestamp}
+import com.wajam.nrv.utils.timestamp.Timestamp
 
 
 /**
  * MRY database
  */
-class Database(var serviceName: String = "database", val timestampGenerator: TimestampGenerator)
+class Database(var serviceName: String = "database")
   extends Service(serviceName) with Logging with Instrumented with Traced {
 
   var storages = Map[String, Storage]()
-
-  private val metricExecuteLocal = tracedTimer("execute-local")
-  private val lastWriteTimestamp = new AtomicReference[Option[Timestamp]](None)
 
   def analyseTransaction(transaction: Transaction): ExecutionContext = {
     val context = new ExecutionContext(storages)
@@ -99,62 +95,18 @@ class Database(var serviceName: String = "database", val timestampGenerator: Tim
   def getStorage(name: String) = this.storages.get(name).get
 
   protected val remoteWriteExecuteToken = this.registerAction(new Action("/execute/:" + Database.TOKEN_KEY, req => {
-    fetchTimestampAndExecute(req)
+    execute(req)
   }, ActionMethod.POST))
   remoteWriteExecuteToken.applySupport(resolver = Some(Database.TOKEN_RESOLVER))
 
   protected val remoteReadExecuteToken = this.registerAction(new Action("/execute/:" + Database.TOKEN_KEY, req => {
-    lastWriteTimestamp.get() match {
-      case Some(timestamp) => metricExecuteLocal.time {
-        execute(timestamp, req)
-      }
-      case None => fetchTimestampAndExecute(req)
-    }
+    execute(req)
   }, ActionMethod.GET))
   remoteReadExecuteToken.applySupport(resolver = Some(Database.TOKEN_RESOLVER))
 
-  private def fetchTimestampAndExecute(req: InMessage) {
-    val timerContext = this.metricExecuteLocal.timerContext()
-    timestampGenerator.fetchTimestamps(serviceName, (timestamps: Seq[Timestamp], optException) => {
-      try {
-        if (optException.isDefined) {
-          info("Exception while fetching timestamps from SCN.", optException.get)
-          throw optException.get
-        }
-        val timestamp = timestamps(0)
-        updateLastTimestamp(timestamp)
-        execute(timestamp, req)
-      } catch {
-        case e: Exception => req.replyWithError(e)
-      } finally {
-        timerContext.stop()
-      }
-    }, 1, req.token)
-  }
-
-  /**
-   * Update last timestamp only if greater than the currently saved timestamp. SCN should not give non increasing
-   * timestamps, but concurrent execution could be executed in a different order. Since we need to be certain that
-   * the last timestamp is effectively the last fetched timestamp, this method must try to set the value as long as
-   * either the new value was atomically set or is obsolete.
-   */
-  private def updateLastTimestamp(timestamp: Timestamp) {
-    var updateSuccessful = false
-    do {
-      val savedTimestamp = lastWriteTimestamp.get()
-      updateSuccessful = savedTimestamp match {
-        case Some(prevTimestamp) => if (timestamp > prevTimestamp) {
-          lastWriteTimestamp.compareAndSet(savedTimestamp, Some(timestamp))
-        } else {
-          true //the timestamp is less than the last timestamp so our value is obsolete
-        }
-        case None => lastWriteTimestamp.compareAndSet(savedTimestamp, Some(timestamp))
-      }
-    } while (!updateSuccessful)
-  }
-
-  private def execute(timestamp: Timestamp, req: InMessage) {
+  private def execute(req: InMessage) {
     var values: Seq[Value] = null
+    val timestamp: Timestamp = req.metadata("timestamp").asInstanceOf[Timestamp]
     val context = new ExecutionContext(storages, Some(timestamp))
     context.cluster = Database.this.cluster
 

--- a/mry-core/src/main/scala/com/wajam/mry/execution/ExecutionContext.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/ExecutionContext.scala
@@ -4,7 +4,7 @@ import com.wajam.mry.storage.{Storage, StorageTransaction => StorageTransaction}
 import com.wajam.nrv.service.Resolver
 import com.wajam.nrv.Logging
 import com.wajam.nrv.cluster.Cluster
-import com.wajam.scn.Timestamp
+import com.wajam.nrv.utils.timestamp.Timestamp
 
 /**
  * Execution context, used to store different information when a transaction

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/Benchmark.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/Benchmark.scala
@@ -113,7 +113,7 @@ object Benchmark extends App with Instrumented {
     cluster.registerService(scn)
     scn.addMember(0, cluster.localNode)
 
-    val db = new Database(scn = scnClient)
+    val db = new Database(timestampGenerator = scnClient)
     db.applySupport(switchboard = Some(new Switchboard("mry", 10, 50)))
     cluster.registerService(db)
     db.addMember(0, cluster.localNode)
@@ -146,7 +146,7 @@ object Benchmark extends App with Instrumented {
 
 
     // TODO: implement distributed testing
-    new Database(scn = null)
+    new Database(timestampGenerator = null)
   }
 
   def getRandomGenerator(id: Int = 0) = new Object {

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
@@ -6,9 +6,9 @@ import collection.mutable
 import com.wajam.mry.execution._
 import com.wajam.mry.api.ProtocolTranslator
 import com.yammer.metrics.scala.Instrumented
-import com.wajam.scn.Timestamp
 import com.wajam.nrv.tracing.Traced
 import java.util.concurrent.atomic.AtomicInteger
+import com.wajam.nrv.utils.timestamp.Timestamp
 
 /**
  * Mysql storage transaction

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableContinuousFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableContinuousFeeder.scala
@@ -3,7 +3,7 @@ package com.wajam.mry.storage.mysql
 import com.wajam.nrv.Logging
 import com.wajam.spnl.feeder.CachedDataFeeder
 import com.wajam.spnl.TaskContext
-import com.wajam.scn.Timestamp
+import com.wajam.nrv.utils.timestamp.Timestamp
 
 /**
  * Fetches all current defined (not null) data on a table.

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableTimelineFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableTimelineFeeder.scala
@@ -3,9 +3,9 @@ package com.wajam.mry.storage.mysql
 import com.wajam.nrv.Logging
 import com.wajam.spnl.feeder.CachedDataFeeder
 import com.wajam.spnl.TaskContext
-import com.wajam.scn.Timestamp
 import com.wajam.mry.storage.mysql.TimelineSelectMode.{FromTimestamp, AtTimestamp}
 import com.wajam.nrv.utils.CurrentTime
+import com.wajam.nrv.utils.timestamp.Timestamp
 
 /**
  * Table mutation timeline task feeder

--- a/mry-core/src/test/scala/com/wajam/mry/TestDatabase.scala
+++ b/mry-core/src/test/scala/com/wajam/mry/TestDatabase.scala
@@ -17,6 +17,7 @@ import com.wajam.nrvext.scribe.ScribeTraceRecorder
 import java.util.UUID
 import org.scalatest.matchers.ShouldMatchers._
 import com.wajam.nrv.zookeeper.cluster.ZookeeperTestingClusterDriver
+import com.wajam.nrv.consistency.ConsistencyMasterSlave
 
 @RunWith(classOf[JUnitRunner])
 class TestDatabase extends FunSuite with BeforeAndAfterAll {
@@ -34,10 +35,13 @@ class TestDatabase extends FunSuite with BeforeAndAfterAll {
     scn.addMember(token, cluster.localNode)
 
     val scnClient = new ScnClient(scn, ScnClientConfig(100)).start()
+    val consistency = new ConsistencyMasterSlave(scnClient)
 
-    val db = new Database("mry", scnClient)
+    val db = new Database("mry")
     cluster.registerService(db)
     db.registerStorage(new MemoryStorage("memory"))
+    db.applySupport(consistency = Some(consistency))
+    consistency.bindService(db)
 
     db.addMember(token, cluster.localNode)
 

--- a/mry-core/src/test/scala/com/wajam/mry/execution/TestTransaction.scala
+++ b/mry-core/src/test/scala/com/wajam/mry/execution/TestTransaction.scala
@@ -5,7 +5,7 @@ import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 import com.wajam.mry.storage.MemoryStorage
 import com.wajam.mry.execution.Implicits._
-import com.wajam.scn.Timestamp
+import com.wajam.nrv.utils.timestamp.Timestamp
 
 @RunWith(classOf[JUnitRunner])
 class TestTransaction extends FunSuite {

--- a/mry-core/src/test/scala/com/wajam/mry/execution/TestTransaction.scala
+++ b/mry-core/src/test/scala/com/wajam/mry/execution/TestTransaction.scala
@@ -12,7 +12,7 @@ class TestTransaction extends FunSuite {
   val storage = new MemoryStorage("memory")
 
   test("token") {
-    var context = new ExecutionContext(Map("memory" -> storage), Some(Timestamp.now))
+    var context = new ExecutionContext(Map("memory" -> storage), Some(Timestamp(0)))
     context.dryMode = true
 
     new Transaction(b => {

--- a/mry-core/src/test/scala/com/wajam/mry/storage/TestMemory.scala
+++ b/mry-core/src/test/scala/com/wajam/mry/storage/TestMemory.scala
@@ -5,8 +5,8 @@ import com.wajam.mry.execution.Implicits._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import com.wajam.mry.execution.{NullValue, Transaction, ExecutionContext}
-import com.wajam.scn.Timestamp
 import com.wajam.scn.storage.ScnTimestamp
+import com.wajam.nrv.utils.timestamp.Timestamp
 
 @RunWith(classOf[JUnitRunner])
 class TestMemory extends FunSuite {

--- a/mry-core/src/test/scala/com/wajam/mry/storage/TestMemory.scala
+++ b/mry-core/src/test/scala/com/wajam/mry/storage/TestMemory.scala
@@ -5,7 +5,6 @@ import com.wajam.mry.execution.Implicits._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import com.wajam.mry.execution.{NullValue, Transaction, ExecutionContext}
-import com.wajam.scn.storage.ScnTimestamp
 import com.wajam.nrv.utils.timestamp.Timestamp
 
 @RunWith(classOf[JUnitRunner])

--- a/mry-core/src/test/scala/com/wajam/mry/storage/TestMemory.scala
+++ b/mry-core/src/test/scala/com/wajam/mry/storage/TestMemory.scala
@@ -6,13 +6,18 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import com.wajam.mry.execution.{NullValue, Transaction, ExecutionContext}
 import com.wajam.scn.Timestamp
+import com.wajam.scn.storage.ScnTimestamp
 
 @RunWith(classOf[JUnitRunner])
 class TestMemory extends FunSuite {
   val storage = new MemoryStorage("memory")
 
+  def createNowTimestamp() = new Timestamp {
+    val value = System.currentTimeMillis() * 10000
+  }
+
   test("commited get set") {
-    var context = new ExecutionContext(Map("memory" -> storage), Some(Timestamp.now))
+    var context = new ExecutionContext(Map("memory" -> storage), Some(createNowTimestamp()))
     var t = new Transaction()
 
     var store = t.from("memory")
@@ -24,7 +29,7 @@ class TestMemory extends FunSuite {
     assert(context.hasToken("key1"))
 
     t = new Transaction()
-    context = new ExecutionContext(Map("memory" -> storage), Some(Timestamp.now))
+    context = new ExecutionContext(Map("memory" -> storage), Some(createNowTimestamp()))
     store = t.from("memory")
     v = store.get("key1")
     store.set("key2", "value2")
@@ -38,7 +43,7 @@ class TestMemory extends FunSuite {
 
   test("uncommited get set") {
     var t = new Transaction()
-    val context = new ExecutionContext(Map("memory" -> storage), Some(Timestamp.now))
+    val context = new ExecutionContext(Map("memory" -> storage), Some(createNowTimestamp()))
     val store = t.from("memory")
     store.set("key3", "value3")
     val v1 = store.get("key2")
@@ -49,7 +54,7 @@ class TestMemory extends FunSuite {
   }
 
   test("delete item shouldn't exist") {
-    var context = new ExecutionContext(Map("memory" -> storage), Some(Timestamp.now))
+    var context = new ExecutionContext(Map("memory" -> storage), Some(createNowTimestamp()))
     var t = new Transaction()
 
     var store = t.from("memory")
@@ -59,7 +64,7 @@ class TestMemory extends FunSuite {
     context.commit()
 
     t = new Transaction()
-    context = new ExecutionContext(Map("memory" -> storage), Some(Timestamp.now))
+    context = new ExecutionContext(Map("memory" -> storage), Some(createNowTimestamp()))
     store = t.from("memory")
     v = store.delete("key1")
     store.set("key2", "value2")
@@ -69,7 +74,7 @@ class TestMemory extends FunSuite {
     context.commit()
 
     t = new Transaction()
-    context = new ExecutionContext(Map("memory" -> storage), Some(Timestamp.now))
+    context = new ExecutionContext(Map("memory" -> storage), Some(createNowTimestamp()))
     store = t.from("memory")
     store.set("key4", "value4")
     store.delete("key4")
@@ -77,7 +82,7 @@ class TestMemory extends FunSuite {
     context.rollback()
 
     t = new Transaction()
-    context = new ExecutionContext(Map("memory" -> storage), Some(Timestamp.now))
+    context = new ExecutionContext(Map("memory" -> storage), Some(createNowTimestamp()))
     store = t.from("memory")
     var v1 = store.get("key1")
     var v2 = store.get("key2")
@@ -92,4 +97,5 @@ class TestMemory extends FunSuite {
     assert(v3.value.isInstanceOf[NullValue])
     assert(v4.value.isInstanceOf[NullValue])
   }
+
 }


### PR DESCRIPTION
The Timestamp trait has been moved from Scn to Nrv. This change requires a simultaneous deployment of all servers (SCN + EDGE)  because the SCN messages are not backward compatible. Deployment will be done during a period of low traffic. Merge to master will only be done once that deployment is planned.
