### PR TITLE
GC truncate all extra versions before going to the next token

### DIFF
--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
@@ -554,9 +554,9 @@ object MysqlTransaction {
   }
 }
 
-class AccessKey(var key: String)
+case class AccessKey(var key: String)
 
-class AccessPath(val parts: Seq[AccessKey] = Seq()) {
+case class AccessPath(parts: Seq[AccessKey] = Seq()) {
   def last = parts.last
 
   def length = parts.length


### PR DESCRIPTION
Also added two new metrics: 
- A gauge with the token curently GCed
- A meter with the number of extra versions loaded when a token in not collected in one GC run. 
