### PR TITLE
Implemented projection for MRY

### DIFF
--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -39,6 +39,94 @@ class TestMysqlStorage extends TestMysqlBase {
     }
   }
 
+  test("should support projection on single record") {
+    val expectedMapValue: MapValue = Map("mapk" -> toVal("value1"))
+    exec(t => {
+      val storage = t.from("mysql")
+      val table = storage.from("table1")
+      table.set("key1", expectedMapValue)
+    }, commit = true)
+
+    val Seq(v) = exec(t => {
+      val storage = t.from("mysql")
+      val table = storage.from("table1")
+      t.ret(table.get("key1").projection("mapk"))
+    }, commit = false)
+
+    assert(v.equalsValue(expectedMapValue))
+  }
+
+  test("should support multiple projection on single record") {
+    val expectedMapValue: MapValue = Map("key1" -> toVal("value1"), "key2" -> toVal("value2"))
+    exec(t => {
+      val storage = t.from("mysql")
+      val table = storage.from("table1")
+      table.set("key1", expectedMapValue)
+    }, commit = true)
+
+    val Seq(v) = exec(t => {
+      val storage = t.from("mysql")
+      val table = storage.from("table1")
+      t.ret(table.get("key1").projection("key1", "key2", "other"))
+    }, commit = false)
+
+    assert(v.equalsValue(expectedMapValue))
+  }
+
+  test("should support projection that results in empty record") {
+    exec(t => {
+      val storage = t.from("mysql")
+      val table = storage.from("table1")
+      table.set("key1", Map("mapk" -> toVal("value1")))
+    }, commit = true)
+
+    val Seq(v) = exec(t => {
+      val storage = t.from("mysql")
+      val table = storage.from("table1")
+      t.ret(table.get("key1").projection("noproj"))
+    }, commit = false)
+
+    assert(v.equalsValue(MapValue(Map[String, Value]())))
+  }
+
+  test("should support projection on record list") {
+    exec(t => {
+      val storage = t.from("mysql")
+      val table = storage.from("table1")
+      table.set("key1", Map("mapk" -> toVal("value1")))
+      val table1_1 = table.get("key1").from("table1_1")
+      table1_1.set("key1", Map("mapk" -> toVal("value1")))
+      table1_1.set("key2", Map("mapk" -> toVal("value2"), "noproj" -> toVal("x")))
+      table1_1.set("key3", Map("noproj" -> toVal("x")))
+    }, commit = true)
+
+    val Seq(ListValue(Seq(MapValue(m1), MapValue(m2), MapValue(m3)))) = exec(t => {
+      val storage = t.from("mysql")
+      val table = storage.from("table1")
+      t.ret(table.get("key1").from("table1_1").get().projection("mapk"))
+    }, commit = false)
+
+    assert(m1 === Map("mapk" -> toVal("value1")))
+    assert(m2 === Map("mapk" -> toVal("value2")))
+    assert(m3.isEmpty)
+  }
+
+  test("should support projection on empty record list") {
+    exec(t => {
+      val storage = t.from("mysql")
+      val table = storage.from("table1")
+      table.set("key1", Map("mapk" -> toVal("value1")))
+    }, commit = true)
+
+    val Seq(ListValue(l)) = exec(t => {
+      val storage = t.from("mysql")
+      val table = storage.from("table1")
+      t.ret(table.get("key1").from("table1_1").get().projection("mapk"))
+    }, commit = false)
+
+    assert(l.isEmpty)
+  }
+
   test("a get before a set should return initial value, not new value") {
     exec(t => {
       val storage = t.from("mysql")

--- a/mry-core/src/main/scala/com/wajam/mry/execution/Operation.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/Operation.scala
@@ -56,5 +56,12 @@ object Operation {
     def reset() {}
   }
 
+  class Projection(source: OperationSource, into: Variable, keys: Object*) extends Operation(source) with Serializable {
+    def execute(context: ExecutionContext) {
+      source.execProjection(context, into, keys: _*)
+    }
+
+    def reset() {}
+  }
 }
 

--- a/mry-core/src/main/scala/com/wajam/mry/execution/OperationApi.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/OperationApi.scala
@@ -62,4 +62,13 @@ trait OperationApi extends OperationSource {
     sourceBlock.addOperation(new Limit(this, into, keys: _*))
     into
   }
+
+  def projection(keys: Object*): Variable = {
+    this.projectionInto(this.sourceBlock.defineVariable(), keys: _*)
+  }
+
+  def projectionInto(into: Variable, keys: Object*): Variable = {
+    sourceBlock.addOperation(new Projection(this, into, keys: _*))
+    into
+  }
 }

--- a/mry-core/src/main/scala/com/wajam/mry/execution/OperationSource.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/OperationSource.scala
@@ -54,6 +54,10 @@ trait OperationSource {
   def execLimit(context: ExecutionContext, into: Variable, keys: Object*) {
     getProxiedSource.execLimit(context, into, keys: _*)
   }
+
+  def execProjection(context: ExecutionContext, into: Variable, keys: Object*) {
+    getProxiedSource.execProjection(context, into, keys: _*)
+  }
 }
 
 class InvalidParameter(reason: String) extends Exception("%s: %s".format(getClass.toString, reason))

--- a/mry-core/src/main/scala/com/wajam/mry/execution/Transaction.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/Transaction.scala
@@ -3,6 +3,7 @@ package com.wajam.mry.execution
 /**
  * MysqlTransaction (block of operations) executed on storage
  */
+@SerialVersionUID(3228033012927254856L)
 class Transaction(blockCreator: (Block with OperationApi) => Unit = null) extends Block with OperationApi with OperationSource with Serializable {
   var id: Int = 0
 

--- a/mry-core/src/main/scala/com/wajam/mry/execution/Value.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/Value.scala
@@ -34,7 +34,11 @@ case class MapValue(mapValue: Map[String, Value]) extends Value {
   }
 
   override def execProjection(context: ExecutionContext, into: Variable, keys: Object*) {
-    into.value = MapValue(mapValue.filter(e => keys.contains(StringValue(e._1))))
+    into.value = if (!keys.isEmpty) {
+      MapValue(mapValue.filter(e => keys.contains(StringValue(e._1))))
+    } else {
+      MapValue(mapValue)
+    }
   }
 }
 
@@ -51,11 +55,14 @@ case class ListValue(listValue: Seq[Value]) extends Value {
   }
 
   override def execProjection(context: ExecutionContext, into: Variable, keys: Object*) {
-    val newList = listValue.map(v => {
-      v.execProjection(context, into, keys: _*)
-      into.value
-    })
-    into.value = ListValue(newList)
+    into.value = if (!keys.isEmpty) {
+      ListValue(listValue.map(v => {
+        v.execProjection(context, into, keys: _*)
+        into.value
+      }))
+    } else {
+      ListValue(listValue)
+    }
   }
 }
 

--- a/mry-core/src/main/scala/com/wajam/mry/execution/Value.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/Value.scala
@@ -32,6 +32,10 @@ case class MapValue(mapValue: Map[String, Value]) extends Value {
     val newMap = for ((k, v) <- mapValue) yield (k -> v.serializableValue)
     new MapValue(newMap)
   }
+
+  override def execProjection(context: ExecutionContext, into: Variable, keys: Object*) {
+    into.value = MapValue(mapValue.filter(e => keys.contains(StringValue(e._1))))
+  }
 }
 
 @SerialVersionUID(3729883700870722479L)
@@ -44,6 +48,14 @@ case class ListValue(listValue: Seq[Value]) extends Value {
   override def serializableValue: Value = {
     val newList = for (oldValue <- listValue) yield oldValue.serializableValue
     new ListValue(newList)
+  }
+
+  override def execProjection(context: ExecutionContext, into: Variable, keys: Object*) {
+    val newList = listValue.map(v => {
+      v.execProjection(context, into, keys: _*)
+      into.value
+    })
+    into.value = ListValue(newList)
   }
 }
 

--- a/mry-core/src/main/scala/com/wajam/mry/execution/Value.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/Value.scala
@@ -14,6 +14,7 @@ trait Value extends Object with OperationSource {
   def isNull = false
 }
 
+@SerialVersionUID(-8696609946517999638L)
 class NullValue extends Value with Serializable {
   override def equalsValue(that: Value): Boolean = this.isInstanceOf[NullValue]
   override def isNull = true

--- a/mry-core/src/main/scala/com/wajam/mry/execution/Variable.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/Variable.scala
@@ -3,6 +3,7 @@ package com.wajam.mry.execution
 /**
  * Variable that can points to nothing or to a value
  */
+@SerialVersionUID(-2511774283683367275L)
 class Variable(var block: Block, var id: Int, var value: Value = NullValue) extends Object with OperationSource with OperationApi with Serializable {
   def sourceBlock = block
 

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MultipleRecordValue.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MultipleRecordValue.scala
@@ -46,6 +46,9 @@ class MultipleRecordValue(storage: MysqlStorage, context: ExecutionContext, tabl
     }
   }
 
+  // Operations are executed on records (list of map or null)
+  override def proxiedSource: Option[OperationSource] = Some(this.innerValue)
+
   override def execLimit(context: ExecutionContext, into: Variable, keys: Object*) {
     if (loaded) {
       val newRec = new MultipleRecordValue(storage, context, table, token, accessPrefix)


### PR DESCRIPTION
This implementation is MRY only and not specific to MySql storage. 

Projection is only implemented for data structures (i.e. MapValue and ListValue). Applying projection on anything else will result in an exception.
