### PR TITLE
No percolation or GC beyond last consistent timestamp per token range

### DIFF
--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlBase.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlBase.scala
@@ -27,6 +27,7 @@ abstract class TestMysqlBase extends FunSuite with BeforeAndAfterEach {
       MysqlStorageConfiguration("mysql", "localhost", "mry", "mry", "mry", gcTokenStep = TokenRange.MaxToken),
       garbageCollection = false)
     storages = Map(("mysql" -> storage))
+    storage.setLastConsistentTimestamp(Long.MaxValue, Seq(TokenRange.All))
 
     storage.nuke()
     storage.syncModel(model)

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -383,7 +383,7 @@ class TestMysqlStorage extends TestMysqlBase {
   }
 
   test("deletion should be a tombstone record") {
-    val transac = new MysqlTransaction(mysqlStorage, None, new MysqlTransaction.Metrics(mysqlStorage))
+    val transac = new MysqlTransaction(mysqlStorage, None)
     val initRec = new Record(table1, Map("test" -> 1234))
     val path = new AccessPath(Seq(new AccessKey("test1")))
     transac.set(table1, 1, createNowTimestamp(), path, Some(initRec))
@@ -543,6 +543,7 @@ class TestMysqlStorage extends TestMysqlBase {
     val token1 = context.getToken("key1")
     val token2 = context.getToken("key2")
     val ranges = List(TokenRange(token1, token1), TokenRange(token2, token2))
+    mysqlStorage.setLastConsistentTimestamp(Long.MaxValue, ranges)
     val table1RangeTimeline = mysqlStorage.createStorageTransaction(context).getTimeline(table1, createTimestamp(0), 100, ranges)
     val allKeys = table1Timeline.map(_.accessPath.toString)
     val expectedRangeKeys = table1Timeline.filter(r => token1 == r.token || token2 == r.token).map(_.accessPath.toString)
@@ -698,7 +699,7 @@ class TestMysqlStorage extends TestMysqlBase {
 
     def getTokenVersion(token: Long): Option[VersionRecord] = {
       var trx = mysqlStorage.createStorageTransaction
-      val versions = trx.getTopMostVersions(table1, token, token, 10)
+      val versions = trx.getTopMostVersions(table1, token, token, Long.MaxValue, 10)
       trx.rollback()
 
       versions.size should be <= 1
@@ -749,7 +750,7 @@ class TestMysqlStorage extends TestMysqlBase {
 
     def getSecondaryVersionCount: Int = {
       var trx = mysqlStorage.createStorageTransaction
-      val versions = trx.getTopMostVersions(table2_1, token, token, 1000)
+      val versions = trx.getTopMostVersions(table2_1, token, token, Long.MaxValue, 1000)
       trx.rollback()
 
       versions.foldLeft(0)((count, version) => count + version.versionsCount)
@@ -757,7 +758,7 @@ class TestMysqlStorage extends TestMysqlBase {
 
     def getSecondaryLoadedVersionCount(k2: Int): Int = {
       var trx = mysqlStorage.createStorageTransaction
-      val versions = trx.getTopMostVersions(table2_1, token, token, 1000)
+      val versions = trx.getTopMostVersions(table2_1, token, token, Long.MaxValue, 1000)
       trx.rollback()
 
       val path = "%s/%d".format(k1, k2)
@@ -784,6 +785,7 @@ class TestMysqlStorage extends TestMysqlBase {
     }
 
     val ranges = List(TokenRange(1000000001L, 2000000000L), TokenRange(3000000001L, 4000000000L))
+    mysqlStorage.setLastConsistentTimestamp(Long.MaxValue, ranges)
     mysqlStorage.GarbageCollector.setCollectedRanges(ranges)
 
     // Create 5 versions for each token/keys tupple
@@ -828,7 +830,7 @@ class TestMysqlStorage extends TestMysqlBase {
       var trx = mysqlStorage.createStorageTransaction
       keys.foreach(entry => {
         val (t, k) = entry
-        val versions = trx.getTopMostVersions(table1, t, t, 10)
+        val versions = trx.getTopMostVersions(table1, t, t, Long.MaxValue, 10)
 
         if (collectedRanges.exists(_.contains(t))) {
           // tupple is in the collected range, no extra version should be available
@@ -840,6 +842,22 @@ class TestMysqlStorage extends TestMysqlBase {
       })
       trx.rollback()
     }
+  }
+
+  test("forced garbage collections should ignore versions after consistent timestamp") {
+    exec(_.from("mysql").from("table1").set("k", Map("k" -> "1")), commit = true, onTimestamp = 100L)
+    exec(_.from("mysql").from("table1").set("k", Map("k" -> "1")), commit = true, onTimestamp = 200L)
+    exec(_.from("mysql").from("table1").set("k", Map("k" -> "1")), commit = true, onTimestamp = 300L)
+    exec(_.from("mysql").from("table1").set("k", Map("k" -> "1")), commit = true, onTimestamp = 400L)
+    exec(_.from("mysql").from("table1").set("k", Map("k" -> "1")), commit = true, onTimestamp = 500L)
+
+    // Force collection, no records collected because there are only 3 versions before the consistent timestamp
+    mysqlStorage.setLastConsistentTimestamp(350L, Seq(TokenRange.All))
+    mysqlStorage.GarbageCollector.collectAll(100) should be(0)
+
+    // Force collection again, all extra records should have been collected
+    mysqlStorage.setLastConsistentTimestamp(500L, Seq(TokenRange.All))
+    mysqlStorage.GarbageCollector.collectAll(100) should be(2)
   }
 
   test("should be able to set the same key twice and keep the last version") {
@@ -1010,6 +1028,7 @@ class TestMysqlStorage extends TestMysqlBase {
 
     val ranges = List(TokenRange(0, 1333333333L), TokenRange(1333333334L, 2666666666L),
       TokenRange(2666666667L, TokenRange.MaxToken))
+    mysqlStorage.setLastConsistentTimestamp(Long.MaxValue, ranges)
 
     var allRecordKeys: List[String] = List()
     for (range <- ranges) {
@@ -1036,6 +1055,7 @@ class TestMysqlStorage extends TestMysqlBase {
 
     val ranges = List(TokenRange(0, 1333333333L), TokenRange(1333333334L, 2666666666L),
       TokenRange(2666666667L, TokenRange.MaxToken))
+    mysqlStorage.setLastConsistentTimestamp(Long.MaxValue, ranges)
 
     for (range <- ranges) {
       var records = mysqlStorage.createStorageTransaction(context).getAllLatest(table1, 40, range).toList

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableContinuousFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableContinuousFeeder.scala
@@ -173,6 +173,7 @@ class TestTableContinuousFeeder extends TestMysqlBase {
     }, commit = true, onTimestamp = createTimestamp(0))
 
     val ranges = List(TokenRange(1000000001L, 2000000000L), TokenRange(3000000001L, 4000000000L))
+    mysqlStorage.setLastConsistentTimestamp(Long.MaxValue, ranges)
     val expectedKeys = keys.filter(k => ranges.exists(_.contains(k._1))).toList
 
     val feeder = new TableContinuousFeeder("test", mysqlStorage, table1, ranges)
@@ -189,5 +190,28 @@ class TestTableContinuousFeeder extends TestMysqlBase {
     // unflattened records =
     //  None (loadMore), range1_records..., None (eor), None (loadMore), range2_records..., None (eor), None (loadMore), range1_records... ...
     records.size should be(71) // Trust me, the count should be 71
+  }
+
+  test("should not return data beyong last consistent timestamp") {
+    exec(t => {
+      t.from("mysql").from("table1").set("key1", Map("k" -> "v"))
+    }, commit = true, onTimestamp = 0L)
+
+    mysqlStorage.setLastConsistentTimestamp(50L, Seq(TokenRange.All))
+
+    exec(t => {
+      t.from("mysql").from("table1").set("key2", Map("k" -> "v"))
+    }, commit = true, onTimestamp = 100L)
+
+    val feeder = new TableContinuousFeeder("test", mysqlStorage, table1, List(TokenRange.All))
+    val records = Iterator.continually({
+      feeder.next()
+    }).take(100).flatten.toList
+
+    records.size should be > 0
+    val strKeys = records.map(_(Keys).asInstanceOf[Seq[String]](0))
+    strKeys.count(_ == "key1") should be(records.size)
+    strKeys.count(_ == "key2") should be(0)
+
   }
 }

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableTimelineFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableTimelineFeeder.scala
@@ -97,6 +97,7 @@ class TestTableTimelineFeeder extends TestMysqlBase {
     })
 
     val ranges = List(TokenRange(1000000001L, 2000000000L), TokenRange(3000000001L, 4000000000L))
+    mysqlStorage.setLastConsistentTimestamp(Long.MaxValue, ranges)
 
     val feeder = new TableTimelineFeeder("test", mysqlStorage, table1, ranges, batchSize)
     feeder.init(new TaskContext())
@@ -104,6 +105,7 @@ class TestTableTimelineFeeder extends TestMysqlBase {
       feeder.next()
     }).take(100).flatten.toList
 
+    records.size should be > 0
     records.size should be < 40
     val timestamps = records.map(_("new_timestamp").toString.toLong)
     timestamps should be(timestamps.sorted)

--- a/mry-core/src/main/scala/com/wajam/mry/ConsistentDatabase.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/ConsistentDatabase.scala
@@ -29,6 +29,16 @@ class ConsistentDatabase[T <: ConsistentStorage](serviceName: String = "database
     storages.values.map(_.getLastTimestamp(ranges)).max
   }
 
+  /**
+   * Set the most recent timestamp considered as consistent by the Consistency manager for the specified token ranges.
+   * The consistency of the records more recent than that timestamp is unconfirmed and must be excluded from the store
+   * job processing (e.g. GC or percolation)
+   */
+  def setLastConsistentTimestamp(timestamp: Timestamp, ranges: Seq[TokenRange]) {
+    for (storage <- storages.values) {
+      storage.setLastConsistentTimestamp(timestamp, ranges)
+    }
+  }
 
   /**
    * Returns the mutation messages from the given timestamp inclusively for the specified token ranges.
@@ -83,12 +93,4 @@ class ConsistentDatabase[T <: ConsistentStorage](serviceName: String = "database
       storage.truncateAt(timestamp, token)
     }
   }
-
-  /**
-   * Truncate all records from the given timestamp inclusively for the specified token ranges.
-   */
-  def truncateFrom(timestamp: Timestamp, tokens: Seq[TokenRange]) {
-    throw new Exception("Not implemented!")
-  }
-
 }

--- a/mry-core/src/main/scala/com/wajam/mry/storage/ConsistentStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/ConsistentStorage.scala
@@ -15,6 +15,13 @@ trait ConsistentStorage extends Storage {
   def getLastTimestamp(ranges: Seq[TokenRange]): Option[Timestamp]
 
   /**
+   * Set the most recent timestamp considered as consistent by the Consistency manager for the specified token ranges.
+   * The consistency of the records more recent than that timestamp is unconfirmed and must be excluded from the storage
+   * job processing (e.g. GC or percolation)
+   */
+  def setLastConsistentTimestamp(timestamp: Timestamp, ranges: Seq[TokenRange])
+
+  /**
    * Returns the mutation transactions from and up to the given timestamps inclusively for the specified token ranges.
    */
   def readTransactions(from: Timestamp, to: Timestamp, ranges: Seq[TokenRange]): Iterator[TransactionRecord]
@@ -23,7 +30,6 @@ trait ConsistentStorage extends Storage {
    * Truncate all records at the given timestamp for the specified token.
    */
   def truncateAt(timestamp: Timestamp, token: Long)
-
 }
 
 trait TransactionRecord {

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
@@ -9,7 +9,7 @@ import com.wajam.mry.storage._
 import com.yammer.metrics.scala.{Meter, Timer, Instrumented}
 import java.util.concurrent.atomic.AtomicInteger
 import collection.mutable
-import java.util.concurrent.{TimeUnit, ScheduledThreadPoolExecutor}
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit, ScheduledThreadPoolExecutor}
 import com.wajam.nrv.service.TokenRange
 import com.yammer.metrics.core.Gauge
 import com.wajam.nrv.utils.timestamp.Timestamp
@@ -20,10 +20,11 @@ import com.wajam.nrv.utils.timestamp.Timestamp
 class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean = true)
   extends Storage with ConsistentStorage with Logging with Value with Instrumented {
   val name = config.name
-  var model: Model = _
-  var transactionMetrics: MysqlTransaction.Metrics = _
-  var tablesMutationsCount = Map[Table, AtomicInteger]()
+  private[mysql]var model: Model = _
+  private[mysql] var transactionMetrics: MysqlTransaction.Metrics = _
+  private var tablesMutationsCount = Map[Table, AtomicInteger]()
   val valueSerializer = new ProtobufTranslator
+  private val lastConsistentTimestamps  = new ConcurrentHashMap[TokenRange, Timestamp]
 
   val datasource = new ComboPooledDataSource()
   datasource.setDriverClass("com.mysql.jdbc.Driver")
@@ -34,9 +35,9 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
   datasource.setMaxPoolSize(config.maxPoolSize)
   datasource.setNumHelperThreads(config.numhelperThread)
 
-  def createStorageTransaction(context: ExecutionContext) = new MysqlTransaction(this, Some(context), transactionMetrics)
+  def createStorageTransaction(context: ExecutionContext) = new MysqlTransaction(this, Some(context))
 
-  def createStorageTransaction = new MysqlTransaction(this, None, transactionMetrics)
+  def createStorageTransaction = new MysqlTransaction(this, None)
 
   def closeStorageTransaction(trx: MysqlTransaction) {
     model.allHierarchyTables.map(table => {
@@ -259,6 +260,21 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
         trx.rollback()
       }
     }
+  }
+
+  /**
+   * Set the most recent timestamp considered as consistent by the Consistency manager for the specified token ranges.
+   * The consistency of the records more recent than that timestamp is unconfirmed and are excluded from the storage
+   * GC or percolation.
+   */
+  def setLastConsistentTimestamp(timestamp: Timestamp, ranges: Seq[TokenRange]) {
+    ranges.foreach(range => {
+      lastConsistentTimestamps.put(range, timestamp)
+    })
+  }
+
+  private[mysql] def getLastConsistentTimestamp(ranges: Seq[TokenRange]): Timestamp = {
+    ranges.map(range => lastConsistentTimestamps.get(range)).min
   }
 
   /**
@@ -654,11 +670,12 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
           val lastToken = tableNextToken
           val lastRange = tableNextRange
           val toToken = math.min(lastToken + config.gcTokenStep, lastRange.end)
+          val lastConsistentToken = getLastConsistentTimestamp(tokenRanges)
 
           // no more versions in cache, fetch new batch
           var nextToken = lastToken
           if (tableVersionsCache.size == 0) {
-            val fetched = trx.getTopMostVersions(table, lastToken, toToken, versionBatchSize)
+            val fetched = trx.getTopMostVersions(table, lastToken, toToken, lastConsistentToken, versionBatchSize)
             tableVersionsCache ++= fetched
 
             if (fetched.size < versionBatchSize) {
@@ -682,7 +699,7 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
               tableVersionsCache.dequeue()
             } else {
               // More versions need to be truncated, reload and update record
-              trx.getTopMostVersions(table, record.token, record.token, versionBatchSize).find(
+              trx.getTopMostVersions(table, record.token, record.token, lastConsistentToken, versionBatchSize).find(
                 _.accessPath == record.accessPath) match {
                 case Some(reloaded) => {
                   extraVersionsLoadedMeter.mark(reloaded.versions.size)

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
@@ -670,12 +670,12 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
           val lastToken = tableNextToken
           val lastRange = tableNextRange
           val toToken = math.min(lastToken + config.gcTokenStep, lastRange.end)
-          val lastConsistentToken = getLastConsistentTimestamp(tokenRanges)
+          val lastConsistentTimestamp = getLastConsistentTimestamp(tokenRanges)
 
           // no more versions in cache, fetch new batch
           var nextToken = lastToken
           if (tableVersionsCache.size == 0) {
-            val fetched = trx.getTopMostVersions(table, lastToken, toToken, lastConsistentToken, versionBatchSize)
+            val fetched = trx.getTopMostVersions(table, lastToken, toToken, lastConsistentTimestamp, versionBatchSize)
             tableVersionsCache ++= fetched
 
             if (fetched.size < versionBatchSize) {
@@ -699,7 +699,7 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
               tableVersionsCache.dequeue()
             } else {
               // More versions need to be truncated, reload and update record
-              trx.getTopMostVersions(table, record.token, record.token, lastConsistentToken, versionBatchSize).find(
+              trx.getTopMostVersions(table, record.token, record.token, lastConsistentTimestamp, versionBatchSize).find(
                 _.accessPath == record.accessPath) match {
                 case Some(reloaded) => {
                   extraVersionsLoadedMeter.mark(reloaded.versions.size)

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
@@ -13,8 +13,8 @@ import com.wajam.nrv.service.TokenRange
 /**
  * Mysql storage transaction
  */
-class MysqlTransaction(private val storage: MysqlStorage, private val context: Option[ExecutionContext],
-                       private val metrics: MysqlTransaction.Metrics) extends StorageTransaction {
+class MysqlTransaction(private val storage: MysqlStorage, private val context: Option[ExecutionContext])
+  extends StorageTransaction {
 
   private[mry] val tableMutationsCount = storage.model.allHierarchyTables.map(table => (table, new AtomicInteger(0))).toMap
   private var lazilyReadValues = List[Value]()
@@ -30,6 +30,8 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
       throw ex
     }
   }
+
+  private def metrics = storage.transactionMetrics
 
   def rollback() {
     if (this.connection != null) {
@@ -241,7 +243,7 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
     }
   }
 
-  def getTimeline(table: Table, timestamp: Timestamp, count: Int, ranges: List[TokenRange] = List(TokenRange.All),
+  def getTimeline(table: Table, timestamp: Timestamp, count: Int, ranges: Seq[TokenRange] = Seq(TokenRange.All),
                   selectMode: TimelineSelectMode = TimelineSelectMode.FromTimestamp): Seq[MutationRecord] = {
     val projKeys = (for (i <- 1 to table.depth) yield "ai.k%1$d".format(i)).mkString(",")
     val whereKeys1 = (for (i <- 1 to table.depth) yield "ai.k%1$d = ad.k%1$d".format(i)).mkString(" AND ")
@@ -250,6 +252,7 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
     val whereKeys4 = (for (i <- 1 to table.depth) yield "bi.k%1$d = bd.k%1$d".format(i)).mkString(" AND ")
     val whereRanges = ranges.map(r => "(ai.tk >= %1$d AND ai.tk <= %2$d)".format(r.start, r.end)).mkString("(", "OR ", ")")
     val fullTableName = table.depthName("_")
+    val lastConsistentTimestamp = storage.getLastConsistentTimestamp(ranges)
 
     /* Generated SQL looks like:
      *
@@ -263,7 +266,7 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
      *           AND ci.ts < ai.ts
      *       )) LEFT JOIN `table1_data` AS bd ON (bi.k1 = bd.k1 AND bi.tk = bd.tk AND bi.ts = bd.ts)
      *     WHERE ((ai.tk >= 0 AND ai.tk <= 89478485) OR (ai.tk >= 536870910 AND ai.tk <= 626349395))
-     *     AND ai.ts >= 0
+     *     AND ai.ts >= 0 AND ai.ts <= 13631089220001
      *     ORDER BY ai.ts ASC
      *     LIMIT 0, 100;
      */
@@ -284,10 +287,10 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
       case TimelineSelectMode.FromTimestamp => {
         sql +=
           """
-            AND ai.ts >= %1$d
+            AND ai.ts >= %1$d AND ai.ts <= %3$d
             ORDER BY ai.ts ASC
             LIMIT 0, %2$d;
-          """.format(timestamp.value, count)
+          """.format(timestamp.value, count, lastConsistentTimestamp.value)
       }
       case TimelineSelectMode.AtTimestamp => {
         sql +=
@@ -317,7 +320,8 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
     ret
   }
 
-  def getTopMostVersions(table: Table, fromToken: Long, toToken: Long, count: Int): Seq[VersionRecord] = {
+  def getTopMostVersions(table: Table, fromToken: Long, toToken: Long, lastConsistentTimestamp: Timestamp,
+                         count: Int): Seq[VersionRecord] = {
     val projKeys = (for (i <- 1 to table.depth) yield "t.k%1$d".format(i)).mkString(",")
     val fullTableName = table.depthName("_")
 
@@ -327,6 +331,7 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
      *    SELECT t.tk, COUNT(*) AS nb, GROUP_CONCAT(t.ts SEPARATOR ',') AS timestamps, t.k1,t.k2,t.k3
      *    FROM `table1_table1_1_table1_1_1_index` AS t
      *    WHERE t.tk >= 0 AND t.tk <= 10000
+     *    AND t.ts <= 13631089220001
      *    GROUP BY t.tk,t.k1,t.k2,t.k3
      *    HAVING COUNT(*) > 3
      *    LIMIT 0, 100
@@ -336,10 +341,11 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
          SELECT t.tk, COUNT(*) AS nb, GROUP_CONCAT(t.ts SEPARATOR ',') AS timestamps, %1$s
          FROM `%2$s_index` AS t
          WHERE t.tk >= %3$d AND t.tk <= %4$d
+         AND t.ts <= %7$d
          GROUP BY t.tk, %1$s
          HAVING COUNT(*) > %5$d
          LIMIT 0, %6$d
-      """.format(projKeys, fullTableName, fromToken, toToken, table.maxVersions, count)
+      """.format(projKeys, fullTableName, fromToken, toToken, table.maxVersions, count, lastConsistentTimestamp.value)
 
 
     var ret = mutable.LinkedList[VersionRecord]()
@@ -509,7 +515,7 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
 
       case None => ("i.tk >= %d".format(range.start), Seq())
     }
-
+    val lastConsistentTimestamp = storage.getLastConsistentTimestamp(Seq(range))
 
     /* Generated SQL looks like:
      *
@@ -519,6 +525,7 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
      *       FROM `table1_index` AS i
      *       WHERE (((i.tk > 4025886270)) OR ((i.tk = 4025886270) AND (k1 > 'key15')))
      *       AND i.tk <= 4525886270
+     *       AND i.ts <= 13631089220001
      *       GROUP BY i.tk, i.k1
      *       ORDER BY i.tk, i.k1
      *       LIMIT 0, 100
@@ -536,6 +543,7 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
             FROM `%2$s_index` AS i
             WHERE (%4$s)
             AND i.tk <= %7$d
+            AND i.ts <= %8$d
             GROUP BY i.tk, %3$s
             ORDER BY i.tk, %3$s
             LIMIT 0, %6$d
@@ -545,7 +553,8 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
         AND o.ts = i.max_ts
         AND o.d IS NOT NULL
         ORDER BY i.tk, %1$s
-              """.format(outerProjKeys, fullTableName, innerProjKeys, recordPosition._1, outerWhereKeys, count, range.end)
+              """.format(outerProjKeys, fullTableName, innerProjKeys, recordPosition._1, outerWhereKeys,
+      count, range.end, lastConsistentTimestamp.value)
 
     var results: SqlResults = null
     try {


### PR DESCRIPTION
The token ranges used in GC and percolation MUST exactly match the ones set by the consistency manager.
