### PR TITLE
Use ArrayBuffer to speed up append operation

### DIFF
--- a/mry-core/src/main/scala/com/wajam/mry/execution/Block.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/Block.scala
@@ -1,13 +1,15 @@
 package com.wajam.mry.execution
 
 import com.wajam.mry.execution.Operation.Return
+import collection.mutable.ArrayBuffer
 
 /**
  * Programmatic block of operations and variables that is executed against storage
  */
 trait Block {
-  var variables = List[Variable]()
-  var operations = List[Operation]()
+  //TODO should not expose these publicly, wait til Protobuf MRY codec is done
+  var variables = ArrayBuffer[Variable]()
+  var operations = ArrayBuffer[Operation]()
   var varSeq = 0
   var parent: Option[Block] = None
 
@@ -21,13 +23,13 @@ trait Block {
 
   def defineVariable(): Variable = {
     val variable = new Variable(this, this.varSeq)
-    this.variables :+= variable
+    this.variables += variable
     this.varSeq += 1
     variable
   }
 
   def addOperation(operation: Operation) {
-    this.operations :+= operation
+    this.operations += operation
   }
 
   def reset() {

--- a/mry-core/src/main/scala/com/wajam/mry/execution/Block.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/Block.scala
@@ -7,7 +7,7 @@ import collection.mutable.ArrayBuffer
  * Programmatic block of operations and variables that is executed against storage
  */
 trait Block {
-  //TODO should not expose these publicly, wait til Protobuf MRY codec is done
+  //TODO change to vals and do not expose these publicly, wait til Protobuf MRY codec is done
   var variables = ArrayBuffer[Variable]()
   var operations = ArrayBuffer[Operation]()
   var varSeq = 0


### PR DESCRIPTION
This is a breaking change as the recipient of the Block will not be able to assign List to ArrayBuffer and vice-versa.

Other option would have been to still use List but prepend element than call reverse before executing, but this is also breaking since the receiver will not have the 'reverse' call and will execute out of order.

This seems to be the safest change to get important (two orders of magnitude) performance improvements on large operation lists.
