### PR TITLE
Rollback storage transaction if execution time > database service response timeout

### DIFF
--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableTimelineFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableTimelineFeeder.scala
@@ -3,9 +3,6 @@ package com.wajam.mry.storage.mysql
 import com.wajam.mry.execution.Implicits._
 import org.scalatest.matchers.ShouldMatchers._
 import com.wajam.spnl.TaskContext
-import org.mockito.Matchers._
-import org.mockito.Mockito._
-import com.wajam.nrv.utils.ControlableCurrentTime
 import com.wajam.nrv.service.TokenRange
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/mry-core/src/test/scala/com/wajam/mry/TestDatabase.scala
+++ b/mry-core/src/test/scala/com/wajam/mry/TestDatabase.scala
@@ -14,6 +14,11 @@ import java.util.UUID
 import org.scalatest.matchers.ShouldMatchers._
 import com.wajam.nrv.zookeeper.cluster.ZookeeperTestingClusterDriver
 import com.wajam.nrv.scribe.ScribeTraceRecorder
+import org.mockito.Mockito._
+import org.mockito.Matchers._
+import org.mockito.stubbing.Answer
+import org.mockito.invocation.InvocationOnMock
+import com.wajam.nrv.TimeoutException
 
 @RunWith(classOf[JUnitRunner])
 class TestDatabase extends FunSuite with BeforeAndAfterAll {
@@ -28,7 +33,7 @@ class TestDatabase extends FunSuite with BeforeAndAfterAll {
 
     val db = new Database[Storage]("mry")
     cluster.registerService(db)
-    db.registerStorage(new MemoryStorage("memory"))
+    db.registerStorage(spy(new MemoryStorage("memory")))
 
     db.addMember(token, cluster.localNode)
 
@@ -82,5 +87,57 @@ class TestDatabase extends FunSuite with BeforeAndAfterAll {
     val driver = new ZookeeperTestingClusterDriver((size, i, manager) => createClusterInstance(size, i, manager))
     driver.execute((driver, instance) => testDatabaseInstance(instance), 6)
     driver.destroy()
+  }
+
+  test("database execute rollback on timeout") {
+    val instance = createClusterInstance(1, 1, new StaticClusterManager)
+
+    try {
+      val db = instance.data.asInstanceOf[Database[_]]
+      db.applySupport(responseTimeout = Some(1000))
+      instance.cluster.start()
+
+      // Set a first value
+      val set1 = Promise[Seq[Value]]
+      db.execute(b => {
+        b.from("memory").set("key", "value1")
+        b.returns(b.from("memory").get("key"))
+      }, set1.complete(_, _))
+      Future.blocking(set1.future, 5000)
+      val Some(Right(Seq(set1Value))) = set1.future.value
+      assert(set1Value.equalsValue("value1"))
+
+      // Add a artificial delay greater than the service response timeout to storage execution.
+      val spyStorage = db.getStorage("memory").asInstanceOf[MemoryStorage]
+      when(spyStorage.createStorageTransaction(anyObject())).thenAnswer(new Answer[spyStorage.MemoryTransaction]() {
+        def answer(invocation: InvocationOnMock) = {
+          Thread.sleep(db.responseTimeout * 2)
+          invocation.callRealMethod().asInstanceOf[spyStorage.MemoryTransaction]
+        }
+      })
+
+      // Set a second value with the delay. Should timeout and the second value should not be set to the storage
+      val set2 = Promise[Seq[Value]]
+      db.execute(b => {
+        b.from("memory").set("key", "value2")
+        b.returns(b.from("memory").get("key"))
+      }, set2.complete(_, _))
+      evaluating {
+        Future.blocking(set2.future, 5000)
+      } should produce[TimeoutException]
+
+      // Remove the delay and fetch the current storage value. Should be the inital value since the second
+      // transaction should had rolledback
+      reset(spyStorage)
+      val get = Promise[Seq[Value]]
+      db.execute(b => {
+        b.returns(b.from("memory").get("key"))
+      }, get.complete(_, _))
+      Future.blocking(get.future, 5000)
+      val Some(Right(Seq(set2Value))) = get.future.value
+      assert(set2Value.equalsValue("value1"))
+    } finally {
+      instance.cluster.stop()
+    }
   }
 }


### PR DESCRIPTION
Before the switchboard was timing out but the MRY transaction wasn't rolled back which produced inconsistencies between the transaction log and the database.
