### PR TITLE
Exclude read transactions iterator records from GC

### DIFF
--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlBase.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlBase.scala
@@ -17,6 +17,7 @@ abstract class TestMysqlBase extends FunSuite with BeforeAndAfterEach {
   val table2 = model.addTable(new Table("table2"))
   val table2_1 = table2.addTable(new Table("table2_1"))
   val table2_1_1 = table2_1.addTable(new Table("table2_1_1"))
+  var currentConsistentTimestamp: Timestamp = Long.MaxValue
 
   override def beforeEach() {
     this.mysqlStorage = newStorageInstance()
@@ -27,7 +28,7 @@ abstract class TestMysqlBase extends FunSuite with BeforeAndAfterEach {
       MysqlStorageConfiguration("mysql", "localhost", "mry", "mry", "mry", gcTokenStep = TokenRange.MaxToken),
       garbageCollection = false)
     storages = Map(("mysql" -> storage))
-    storage.setLastConsistentTimestamp(Long.MaxValue, Seq(TokenRange.All))
+    storage.setCurrentConsistentTimestamp((_) => currentConsistentTimestamp)
 
     storage.nuke()
     storage.syncModel(model)

--- a/mry-core/src/main/scala/com/wajam/mry/ConsistentDatabase.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/ConsistentDatabase.scala
@@ -31,13 +31,13 @@ class ConsistentDatabase[T <: ConsistentStorage](serviceName: String = "database
   }
 
   /**
-   * Set the most recent timestamp considered as consistent by the Consistency manager for the specified token ranges.
-   * The consistency of the records more recent than that timestamp is unconfirmed and must be excluded from the store
-   * job processing (e.g. GC or percolation)
+   * Setup the function which returns the most recent timestamp considered as consistent by the Consistency manager
+   * for the specified token range. The consistency of the records more recent that the consistent timestamp is
+   * unconfirmed and these records must be excluded from processing tasks such as GC or percolation.
    */
-  def setLastConsistentTimestamp(timestamp: Timestamp, ranges: Seq[TokenRange]) {
+  def setCurrentConsistentTimestamp(getCurrentConsistentTimestamp: (TokenRange) => Timestamp) {
     for (storage <- storages.values) {
-      storage.setLastConsistentTimestamp(timestamp, ranges)
+      storage.setCurrentConsistentTimestamp(getCurrentConsistentTimestamp)
     }
   }
 

--- a/mry-core/src/main/scala/com/wajam/mry/storage/ConsistentStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/ConsistentStorage.scala
@@ -16,11 +16,11 @@ trait ConsistentStorage extends Storage {
   def getLastTimestamp(ranges: Seq[TokenRange]): Option[Timestamp]
 
   /**
-   * Set the most recent timestamp considered as consistent by the Consistency manager for the specified token ranges.
-   * The consistency of the records more recent than that timestamp is unconfirmed and must be excluded from the storage
-   * job processing (e.g. GC or percolation)
+   * Setup the function which returns the most recent timestamp considered as consistent by the Consistency manager
+   * for the specified token range. The consistency of the records more recent that the consistent timestamp is
+   * unconfirmed and these records must be excluded from processing tasks such as GC or percolation.
    */
-  def setLastConsistentTimestamp(timestamp: Timestamp, ranges: Seq[TokenRange])
+  def setCurrentConsistentTimestamp(getCurrentConsistentTimestamp: (TokenRange) => Timestamp)
 
   /**
    * Returns the mutation transactions from and up to the given timestamps inclusively for the specified token ranges.

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
@@ -252,7 +252,7 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
     val whereKeys4 = (for (i <- 1 to table.depth) yield "bi.k%1$d = bd.k%1$d".format(i)).mkString(" AND ")
     val whereRanges = ranges.map(r => "(ai.tk >= %1$d AND ai.tk <= %2$d)".format(r.start, r.end)).mkString("(", "OR ", ")")
     val fullTableName = table.depthName("_")
-    val lastConsistentTimestamp = storage.getLastConsistentTimestamp(ranges)
+    val lastConsistentTimestamp = storage.getCurrentConsistentTimestamp(ranges)
 
     /* Generated SQL looks like:
      *
@@ -515,7 +515,7 @@ class MysqlTransaction(private val storage: MysqlStorage, private val context: O
 
       case None => ("i.tk >= %d".format(range.start), Seq())
     }
-    val lastConsistentTimestamp = storage.getLastConsistentTimestamp(Seq(range))
+    val lastConsistentTimestamp = storage.getCurrentConsistentTimestamp(Seq(range))
 
     /* Generated SQL looks like:
      *


### PR DESCRIPTION
Also setup a function to consistent store to lookup the current consistent timestamp.
