### PR TITLE
Support multi keys operations in TableValue to simplify replicated transactions

### DIFF
--- a/mry-core/src/main/scala/com/wajam/mry/execution/OperationSource.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/OperationSource.scala
@@ -24,11 +24,11 @@ trait OperationSource extends ContentEquals  {
 
   def param[T: ClassManifest](params: Seq[Object], position: Int): T = {
     if (params.size <= position)
-      throw new InvalidParameter("Excepted parameter at position %d".format(position))
+      throw new InvalidParameter("Expected parameter at position %d".format(position))
 
     val param = params(position).value
     if (!param.isInstanceOf[T])
-      throw new InvalidParameter("Excepted parameter at position %d to be of instance %s".format(position, classManifest[T].erasure.getName))
+      throw new InvalidParameter("Expected parameter at position %d to be of instance %s".format(position, classManifest[T].erasure.getName))
 
     param.asInstanceOf[T]
   }

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
@@ -241,16 +241,38 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
   }
 
   override def execFrom(context: ExecutionContext, into: Variable, keys: Object*) {
-    val tableName = param[StringValue](keys, 0).strValue
-    val optTable = model.getTable(tableName)
 
-    optTable match {
-      case Some(t) =>
-        into.value = new TableValue(this, t)
+    def getTable(coll: TableCollection, tableNames: List[String]): Table = {
+      if (tableNames == Nil) {
+        coll match {
+          case table: Table => table
+          case _ => throw new StorageException("Non existing table")
+        }
+      } else {
+        coll.getTable(tableNames.head) match {
+          case Some(table) => getTable(table, tableNames.tail)
+          case None => throw new StorageException("Non existing table %s".format(tableNames.head))
+        }
+      }
+    }
 
-      case None =>
-        throw new StorageException("Non existing table %s".format(tableName))
+    into.value = new TableValue(this, getTable(model, extractTableNames(keys:_*)))
+  }
 
+  private def extractTableNames(params: Object*): List[String] = {
+    params(0) match {
+      case StringValue(tableName) => {
+        List(tableName)
+      }
+      case ListValue(values) => {
+        values.map {
+          case StringValue(tableName) => tableName
+          case _ => throw new InvalidParameter("Expected parameter at position 0 to be of instance ListValue[Seq[StringValue]]")
+        }.toList
+      }
+      case _ => {
+        throw new InvalidParameter("Expected parameter at position 0 to be of instance StringValue or ListValue")
+      }
     }
   }
 
@@ -370,25 +392,12 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
       // Set or delete each record
       val storage = transaction.from("mysql")
       for (record <- records.sortBy(_.table.depth)) {
-
-        // Select the parent table if any
-        val parent = record.table.parentTable match {
-          case Some(tableParent) => {
-            tableParent.path.zip(record.accessPath.keys).foldLeft(storage) {
-              case (p, (t, k)) => {
-                p.from(t.name).get(k)
-              }
-            }
-          }
-          case None => storage
-        }
-
-        // Finally set or delete the record data
-        val table = parent.from(record.table.name)
+        val tableNames = record.table.path.map(_.name)
+        val keys = record.accessPath.keys
         if (record.value.isNull) {
-          table.delete(record.accessPath.last.key)
+          storage.from(tableNames).delete(keys)
         } else {
-          table.set(record.accessPath.last.key, record.value)
+          storage.from(tableNames).set(keys, record.value)
         }
       }
     }

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
@@ -14,6 +14,7 @@ import com.wajam.nrv.service.TokenRange
 import com.yammer.metrics.core.Gauge
 import com.wajam.nrv.utils.timestamp.Timestamp
 import com.wajam.nrv.utils.Closable
+import annotation.tailrec
 
 /**
  * MySQL backed storage
@@ -242,10 +243,11 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
 
   override def execFrom(context: ExecutionContext, into: Variable, keys: Object*) {
 
+    @tailrec
     def getTable(coll: TableCollection, tableNames: List[String]): Option[Table] = {
       tableNames match {
         case Nil => None
-        case head :: Nil => coll.getTable(tableNames.head)
+        case head :: Nil => coll.getTable(head)
         case head :: tail => {
           coll.getTable(head) match {
             case Some(table) => getTable(table, tail)


### PR DESCRIPTION
Prevent errors when parent record does not exist at the replicated timestamp (i.e. when all parent records before that timestamp removed by GC).
