### PR TITLE
Fix replication slow queries

### DIFF
--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -1333,23 +1333,23 @@ class TestMysqlStorage extends TestMysqlBase with ShouldMatchers {
     val grp8 = spyStorage.MutationGroup(tk8, 8L, List(Record(table1, tk8, 8L, NullValue, "k8")))
 
     // After first and before last
-    val grp2to7 = new spyStorage.MutationGroupIterator(fromTime = 2L, toTime = 7L, List(TokenRange.All), 4, 1, 1)
+    val grp2to7 = new spyStorage.MutationGroupIterator(startTimestamp = 2L, endTimestamp = 7L, List(TokenRange.All), 4, 1, 1, 1)
     grp2to7.toList should be(List(grp2, grp3, grp4, grp5, grp6, grp7))
 
     // Same from and to
-    val grp1to1 = new spyStorage.MutationGroupIterator(fromTime = 1L, toTime = 1L, List(TokenRange.All), 4, 2, 1)
+    val grp1to1 = new spyStorage.MutationGroupIterator(startTimestamp = 1L, endTimestamp = 1L, List(TokenRange.All), 4, 2, 1, 1)
     grp1to1.toList should be(List(grp1))
 
     // Before first
-    val grp0to3 = new spyStorage.MutationGroupIterator(fromTime = 0L, toTime = 3L, List(TokenRange.All), 4, 2, 1)
+    val grp0to3 = new spyStorage.MutationGroupIterator(startTimestamp = 0L, endTimestamp = 3L, List(TokenRange.All), 4, 2, 1, 1)
     grp0to3.toList should be(List(grp1, grp2, grp3))
 
     // Beyond last
-    val grp5to9 = new spyStorage.MutationGroupIterator(fromTime = 5L, toTime = 9L, List(TokenRange.All), 4, 2, 1)
+    val grp5to9 = new spyStorage.MutationGroupIterator(startTimestamp = 5L, endTimestamp = 9L, List(TokenRange.All), 4, 2, 1, 1)
     grp5to9.toList should be(List(grp5, grp6, grp7, grp8))
 
     // Loading records error
-    val grpError = new spyStorage.MutationGroupIterator(fromTime = 1L, toTime = 3L, List(TokenRange.All), 4, 2, 1)
+    val grpError = new spyStorage.MutationGroupIterator(startTimestamp = 1L, endTimestamp = 3L, List(TokenRange.All), 4, 2, 1, 1)
     when(spyStorage.createStorageTransaction).thenThrow(new RuntimeException())
     evaluating {
       grpError.next()
@@ -1377,7 +1377,7 @@ class TestMysqlStorage extends TestMysqlBase with ShouldMatchers {
     val grp1 = storage.MutationGroup(tk1, ts1, List(table1_r1, table1_1_r2, table1_1_r1, table1_1_1_r1))
 
     // Verify database is empty before
-    val before = new storage.MutationGroupIterator(fromTime = 0L, toTime = 3L, ranges = List(TokenRange.All))
+    val before = new storage.MutationGroupIterator(startTimestamp = 0L, endTimestamp = 3L, ranges = List(TokenRange.All))
     before.toList should be(List())
 
     // Generate mutations transaction and apply the operations
@@ -1388,7 +1388,7 @@ class TestMysqlStorage extends TestMysqlBase with ShouldMatchers {
     }, commit = true, onTimestamp = ts1)
 
     // Ensure mutations are applied to database
-    val after = new storage.MutationGroupIterator(fromTime = 0L, toTime = 3L, ranges = List(TokenRange.All)).toList
+    val after = new storage.MutationGroupIterator(startTimestamp = 0L, endTimestamp = 3L, ranges = List(TokenRange.All)).toList
     //TODO find root cause... (Order is not important for this)
     after.foreach(mutation => mutation.records = mutation.records.sortWith((r1, r2) => r1.table.path.toString() < r2.table.path.toString()))
     after should be(List(grp1))


### PR DESCRIPTION
Use a timestamp upper bound of 24 hours when fetching table summary records.
