### PR TITLE
New default Database current consistent timestamps hook

### DIFF
--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
@@ -26,7 +26,7 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
   private[mysql] var transactionMetrics: MysqlTransaction.Metrics = null
   private var tablesMutationsCount = Map[Table, AtomicInteger]()
   val valueSerializer = new ProtobufTranslator
-  private var currentConsistentTimestamps: (TokenRange) => Timestamp = (_) => Long.MinValue
+  private var currentConsistentTimestamps: (TokenRange) => Timestamp = (_) => Long.MaxValue
   private var openReadIterators: List[MutationGroupIterator] = List()
 
   lazy private val lastTimestampTimer = metrics.timer("get-last-timestamp-time")


### PR DESCRIPTION
Now allows MysqlStorage percolation and GC on all data by default. Doesn't need to be hooked with ConsistencyMasterSlave anymore.
