### PR TITLE
TableContinuousFeeder is now a mixable trait

### DIFF
--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
@@ -5,12 +5,12 @@ import com.wajam.mry.execution._
 import org.scalatest.matchers.ShouldMatchers._
 import com.wajam.nrv.service.TokenRange
 import com.wajam.spnl.TaskContext
-import com.wajam.mry.storage.mysql.TableContinuousFeeder._
+import com.wajam.mry.storage.mysql.TableAllLatestFeeder._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class TestTableContinuousFeeder extends TestMysqlBase {
+class TestTableAllLatestFeeder extends TestMysqlBase {
 
   test("continuous feeder should feed in loop a table and in token+key order") {
     val context = new ExecutionContext(storages)
@@ -25,7 +25,7 @@ class TestTableContinuousFeeder extends TestMysqlBase {
     }, commit = true, onTimestamp = createTimestamp(0))
 
 
-    val feeder = new TableContinuousFeeder("test", mysqlStorage, table1, List(TokenRange.All))
+    val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1, List(TokenRange.All))
     val records = Iterator.continually({
       feeder.next()
     }).take(100).flatten.toList
@@ -54,7 +54,7 @@ class TestTableContinuousFeeder extends TestMysqlBase {
     }
 
     // Should load records starting from context data record
-    val feeder = new TableContinuousFeeder("test", mysqlStorage, table1, List(TokenRange.All))
+    val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1, List(TokenRange.All))
     val feederContext = new TaskContext()
     feederContext.data += (Token -> keys(5)._1)
     feederContext.data += (Keys -> Seq(keys(5)._2))
@@ -82,7 +82,7 @@ class TestTableContinuousFeeder extends TestMysqlBase {
     }
 
     // Should load records from start
-    val feeder = new TableContinuousFeeder("test", mysqlStorage, table1, List(TokenRange.All))
+    val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1, List(TokenRange.All))
     val feederContext = new TaskContext()
     feederContext.data += (Token -> keys(5))
     feederContext.data += (Keys -> Seq(keys(5)._2))
@@ -110,7 +110,7 @@ class TestTableContinuousFeeder extends TestMysqlBase {
     }
 
     // Should load records from start
-    val feeder = new TableContinuousFeeder("test", mysqlStorage, table1, List(TokenRange.All))
+    val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1, List(TokenRange.All))
     feeder.init(new TaskContext())
     val records = Iterator.continually({
       feeder.next()
@@ -135,7 +135,7 @@ class TestTableContinuousFeeder extends TestMysqlBase {
     }
 
     // Load some records
-    val feeder1 = new TableContinuousFeeder("test", mysqlStorage, table1_1, List(TokenRange.All))
+    val feeder1 = new TableAllLatestFeeder("test", mysqlStorage, table1_1, List(TokenRange.All))
     feeder1.init(new TaskContext())
     val records = Iterator.continually({
       feeder1.next()
@@ -148,7 +148,7 @@ class TestTableContinuousFeeder extends TestMysqlBase {
     feeder1.ack(records.last)
 
     // Create another feeder instance with a copy of the context, should resume from the previous feeder context
-    val feeder2 = new TableContinuousFeeder("test", mysqlStorage, table1_1, List(TokenRange.All))
+    val feeder2 = new TableAllLatestFeeder("test", mysqlStorage, table1_1, List(TokenRange.All))
     val context2 = new TaskContext()
     context2.updateFromJson(feeder1.context.toJson)
     feeder2.init(context2)
@@ -175,7 +175,7 @@ class TestTableContinuousFeeder extends TestMysqlBase {
     val ranges = List(TokenRange(1000000001L, 2000000000L), TokenRange(3000000001L, 4000000000L))
     val expectedKeys = keys.filter(k => ranges.exists(_.contains(k._1))).toList
 
-    val feeder = new TableContinuousFeeder("test", mysqlStorage, table1, ranges)
+    val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1, ranges)
     val records = Iterator.continually({
       feeder.next()
     }).take(100).flatten.toList
@@ -202,7 +202,7 @@ class TestTableContinuousFeeder extends TestMysqlBase {
 
     currentConsistentTimestamp = 50L
 
-    val feeder = new TableContinuousFeeder("test", mysqlStorage, table1, List(TokenRange.All))
+    val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1, List(TokenRange.All))
     val records = Iterator.continually({
       feeder.next()
     }).take(100).flatten.toList

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableContinuousFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableContinuousFeeder.scala
@@ -1,0 +1,98 @@
+package com.wajam.mry.storage.mysql
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FunSuite
+import org.scalatest.matchers.ShouldMatchers._
+import com.wajam.nrv.service.TokenRange
+import com.wajam.spnl.TaskContext
+import org.mockito.Mockito._
+
+@RunWith(classOf[JUnitRunner])
+class TestTableContinuousFeeder extends FunSuite {
+
+  /**
+   * Test feeder which use token as record. When loading records, it simply enumerates all the tokens in the
+   * specified token range.
+   */
+  class ContinuousTokenFeeder(val tokenRanges: Seq[TokenRange], limit: Int)
+    extends ResumableRecordDataFeeder with TableContinuousFeeder {
+
+    type DataRecord = Long
+
+    val name = "ContinuousTokenFeeder"
+
+    def token(record: Long) = record
+
+    def loadRecords(range: TokenRange, fromRecord: Option[Long]) = {
+      (fromRecord match {
+        case Some(start) => start.to(range.end)
+        case None => range.start.to(range.end)
+      }).take(limit)
+    }
+
+    def toRecord(data: Map[String, Any]) = data.get("token").map(_.toString.toLong)
+
+    def toData(record: Long) = Map("token" -> record)
+  }
+
+  test("feeder should loop when loaded all data - large load limit") {
+    val ranges = Seq(TokenRange(2, 5), TokenRange(10, 12))
+    val feeder = new ContinuousTokenFeeder(ranges, limit = 1000)
+    val records = Iterator.continually(feeder.next()).take(50).flatten.toList
+    records.flatMap(feeder.toRecord).take(15) should be (List(2, 3, 4, 5, 10, 11, 12, 2, 3, 4, 5, 10, 11, 12, 2))
+  }
+
+  test("feeder should loop when loaded all data - small load limit") {
+    val ranges = Seq(TokenRange(2, 5), TokenRange(10, 12))
+    val feeder = new ContinuousTokenFeeder(ranges, limit = 2)
+    val records = Iterator.continually(feeder.next()).take(50).flatten.toList
+    records.flatMap(feeder.toRecord).take(15) should be (List(2, 3, 4, 5, 10, 11, 12, 2, 3, 4, 5, 10, 11, 12, 2))
+  }
+
+  test("should resume from context position") {
+    val ranges = Seq(TokenRange(2, 5), TokenRange(10, 12))
+    val feeder = new ContinuousTokenFeeder(ranges, limit = 10)
+    feeder.init(TaskContext(Map("token" -> 11)))
+    val records = Iterator.continually(feeder.next()).take(50).flatten.toList
+    records.flatMap(feeder.toRecord).take(15) should be (List(12, 2, 3, 4, 5, 10, 11, 12, 2, 3, 4, 5, 10, 11, 12))
+  }
+
+  test("should start from beginning when out of range context position") {
+    val ranges = Seq(TokenRange(2, 5), TokenRange(10, 12))
+    val feeder = new ContinuousTokenFeeder(ranges, limit = 10)
+    feeder.init(TaskContext(Map("token" -> 8)))
+    val records = Iterator.continually(feeder.next()).take(50).flatten.toList
+    records.flatMap(feeder.toRecord).take(15) should be (List(2, 3, 4, 5, 10, 11, 12, 2, 3, 4, 5, 10, 11, 12, 2))
+  }
+
+  test("should start from beginning when context is empty") {
+    val ranges = Seq(TokenRange(2, 5), TokenRange(10, 12))
+    val feeder = new ContinuousTokenFeeder(ranges, limit = 10)
+    feeder.init(TaskContext())
+    val records = Iterator.continually(feeder.next()).take(50).flatten.toList
+    records.flatMap(feeder.toRecord).take(15) should be (List(2, 3, 4, 5, 10, 11, 12, 2, 3, 4, 5, 10, 11, 12, 2))
+  }
+
+  test("should resume from same position if load fail") {
+    val ranges = List(TokenRange(2, 5), TokenRange(10, 12))
+    val feeder = new ContinuousTokenFeeder(ranges, limit = 2)
+    val spyFeeder = spy(feeder)
+
+    when(spyFeeder.loadRecords(TokenRange(10, 12), Some(11L))).thenThrow(new RuntimeException())
+    val recordsWithError = Iterator.continually(spyFeeder.next()).take(50).flatten.toList
+    recordsWithError.flatMap(feeder.toRecord) should be (List(2, 3, 4, 5, 10, 11))
+
+    reset(spyFeeder)
+    val records = Iterator.continually(spyFeeder.next()).take(50).flatten.toList
+    records.flatMap(feeder.toRecord).take(15) should be (List(12, 2, 3, 4, 5, 10, 11, 12, 2, 3, 4, 5, 10, 11, 12))
+  }
+
+  test("should save last ack position in context") {
+    val ranges = Seq(TokenRange(2, 5), TokenRange(10, 12))
+    val feeder = new ContinuousTokenFeeder(ranges, limit = 10)
+    feeder.init(TaskContext())
+    feeder.ack(feeder.toData(11L))
+    feeder.toRecord(feeder.context.data) should be (Some(11L))
+  }
+}

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
@@ -329,7 +329,7 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
             if (trx != null)
               trx.rollback()
           } catch {
-            case _ =>
+            case _: Exception =>
           }
 
           error("Caught an exception while truncating records storage (tk={}, ts={})", token, timestamp, e)
@@ -839,7 +839,7 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
               if (trx != null)
                 trx.rollback()
             } catch {
-              case _ =>
+              case _: Exception =>
             }
 
             error("Caught an exception in {} garbage collector!", table.uniqueName, e)

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/RecordDataFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/RecordDataFeeder.scala
@@ -21,9 +21,11 @@ trait ResumableRecordDataFeeder extends RecordDataFeeder {
 
   def loadRecords(range: TokenRange, fromRecord: Option[DataRecord]): Iterable[DataRecord]
 
+  def toContextData(data: Map[String, Any]): Map[String, Any] = data
+
   def ack(data: Map[String, Any]) {
     // Update context with the latest acknowledged record data
-    context.data = data.map(entry => entry match {
+    context.data = toContextData(data).map(entry => entry match {
       case (k, v: String) => (k, v)
       case (k, v: Seq[Any]) => (k, v.map(_.toString))
       case (k, v) => (k, v.toString)

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/RecordDataFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/RecordDataFeeder.scala
@@ -1,0 +1,33 @@
+package com.wajam.mry.storage.mysql
+
+import com.wajam.nrv.service.TokenRange
+import com.wajam.spnl.feeder.Feeder
+import com.wajam.spnl.TaskContext
+
+trait RecordDataFeeder extends Feeder {
+
+  type DataRecord
+
+  def toRecord(data: Map[String, Any]): Option[DataRecord]
+
+  def toData(record: DataRecord): Map[String, Any]
+}
+
+trait ResumableRecordDataFeeder extends RecordDataFeeder {
+
+  def context: TaskContext
+
+  def token(record: DataRecord): Long
+
+  def loadRecords(range: TokenRange, fromRecord: Option[DataRecord]): Iterable[DataRecord]
+
+  def ack(data: Map[String, Any]) {
+    // Update context with the latest acknowledged record data
+    context.data = data.map(entry => entry match {
+      case (k, v: String) => (k, v)
+      case (k, v: Seq[Any]) => (k, v.map(_.toString))
+      case (k, v) => (k, v.toString)
+    })
+  }
+
+}

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
@@ -6,7 +6,6 @@ import com.wajam.nrv.service.TokenRange
 
 /**
  * Fetches all current defined (not null) data on a table.
- * When it finished, it loops over and starts again with the oldest current data.
  */
 abstract class TableAllLatestFeeder(val name: String, storage: MysqlStorage, table: Table,
                                     val tokenRanges: Seq[TokenRange], loadLimit: Int = 1000)

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
@@ -9,11 +9,11 @@ import com.wajam.nrv.service.TokenRange
  * Fetches all current defined (not null) data on a table.
  * When it finished, it loops over and starts again with the oldest current data.
  */
-class TableContinuousFeeder(name: String, storage: MysqlStorage, table: Table, tokenRanges: Seq[TokenRange],
+class TableAllLatestFeeder(name: String, storage: MysqlStorage, table: Table, tokenRanges: Seq[TokenRange],
                             rowsToFetch: Int = 1000)
   extends CachedDataFeeder(name) with Logging {
 
-  import TableContinuousFeeder._
+  import TableAllLatestFeeder._
 
   var context: TaskContext = null
   var lastRecord: Option[Record] = None
@@ -111,7 +111,7 @@ class TableContinuousFeeder(name: String, storage: MysqlStorage, table: Table, t
   def kill() {}
 }
 
-object TableContinuousFeeder {
+object TableAllLatestFeeder {
   val Keys = "keys"
   val Token = "token"
   val Value = "value"

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
@@ -3,6 +3,7 @@ package com.wajam.mry.storage.mysql
 import com.wajam.nrv.Logging
 import com.wajam.spnl.feeder.CachedDataFeeder
 import com.wajam.nrv.service.TokenRange
+import com.wajam.mry.execution.{NullValue, Value}
 
 /**
  * Fetches all current defined (not null) data on a table.
@@ -30,12 +31,12 @@ abstract class TableAllLatestFeeder(val name: String, storage: MysqlStorage, tab
     if (data.contains(Keys) && data.contains(Token) && data.contains(Timestamp))
     {
       try {
-        val record = new Record(table)
-        record.token = data(Token).toString.toLong
-        record.timestamp = com.wajam.nrv.utils.timestamp.Timestamp(data(Timestamp).toString.toLong)
+        val token = data(Token).toString.toLong
+        val timestamp = com.wajam.nrv.utils.timestamp.Timestamp(data(Timestamp).toString.toLong)
         val keys = data(Keys).asInstanceOf[Seq[String]]
-        record.accessPath = new AccessPath(keys.map(new AccessKey(_)))
-        Some(record)
+        val accessPath = new AccessPath(keys.map(new AccessKey(_)))
+        val value = data.get(Value).getOrElse(NullValue).asInstanceOf[Value]
+        Some(new Record(table, value, token, accessPath, timestamp = timestamp))
       } catch {
         case e: Exception => {
           warn("Error creating Record for table {} from task context data {}: ", table.depthName("_"), data, e)

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
@@ -55,10 +55,7 @@ abstract class TableAllLatestFeeder(val name: String, storage: MysqlStorage, tab
       Timestamp -> record.timestamp)
   }
 
-  override def ack(data: Map[String, Any]) {
-    // Exclude value from context
-    super.ack(data - Value)
-  }
+  override def toContextData(data: Map[String, Any]): Map[String, Any] = data - Value
 }
 
 object TableAllLatestFeeder {

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableContinuousFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableContinuousFeeder.scala
@@ -1,0 +1,64 @@
+package com.wajam.mry.storage.mysql
+
+import com.wajam.nrv.service.TokenRange
+import com.wajam.spnl.feeder.CachedDataFeeder
+import com.wajam.nrv.Logging
+import com.wajam.spnl.TaskContext
+
+trait TableContinuousFeeder extends CachedDataFeeder with ResumableRecordDataFeeder with Logging {
+
+  private var currentContext: TaskContext = null
+  private var lastRecord: Option[DataRecord] = None
+  private var currentRange: Option[TokenRange] = None
+
+  def tokenRanges: Seq[TokenRange]
+
+  def context: TaskContext = currentContext
+
+  def init(context: TaskContext) {
+    currentContext = context
+    lastRecord = toRecord(context.data)
+  }
+
+  def loadMore() = {
+    try {
+      val loadRange = lastRecord match {
+        case Some(record) => {
+          println("1) lastRecord=%s, curRange=%s, newRange=%s".format(lastRecord, currentRange,
+            tokenRanges.find(_.contains(token(record))).getOrElse(tokenRanges.head)))
+          tokenRanges.find(_.contains(token(record))).getOrElse(tokenRanges.head)
+        }
+        case None => {
+          currentRange match {
+            case Some(range) => {
+              println("2) lastRecord=%s, curRange=%s, newRange=%s".format(lastRecord, currentRange,
+                range.nextRange(tokenRanges).getOrElse(tokenRanges.head)))
+              range.nextRange(tokenRanges).getOrElse(tokenRanges.head)
+            }
+            case None => {
+              println("3) lastRecord=%s, curRange=%s, newRange=%s".format(lastRecord, currentRange, tokenRanges.head))
+              tokenRanges.head
+            }
+          }
+        }
+      }
+      currentRange = Some(loadRange)
+
+      // The loadRecords method may returns the "from" record, we remove it first. TODO: should this be done in loadRecords?
+      val records = lastRecord match {
+        case Some(record) => loadRecords(loadRange, lastRecord).filterNot(_ == record)
+        case None => loadRecords(loadRange, lastRecord)
+      }
+      lastRecord = records.lastOption
+
+      records.map(toData).toList
+    } catch {
+      case e: Exception => {
+        error("An exception occured while loading more elements for {}", name, e)
+        Nil
+      }
+    }
+  }
+
+  def kill() {}
+}

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableContinuousFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableContinuousFeeder.scala
@@ -23,28 +23,17 @@ trait TableContinuousFeeder extends CachedDataFeeder with ResumableRecordDataFee
   def loadMore() = {
     try {
       val loadRange = lastRecord match {
-        case Some(record) => {
-          println("1) lastRecord=%s, curRange=%s, newRange=%s".format(lastRecord, currentRange,
-            tokenRanges.find(_.contains(token(record))).getOrElse(tokenRanges.head)))
-          tokenRanges.find(_.contains(token(record))).getOrElse(tokenRanges.head)
-        }
+        case Some(record) => tokenRanges.find(_.contains(token(record))).getOrElse(tokenRanges.head)
         case None => {
           currentRange match {
-            case Some(range) => {
-              println("2) lastRecord=%s, curRange=%s, newRange=%s".format(lastRecord, currentRange,
-                range.nextRange(tokenRanges).getOrElse(tokenRanges.head)))
-              range.nextRange(tokenRanges).getOrElse(tokenRanges.head)
-            }
-            case None => {
-              println("3) lastRecord=%s, curRange=%s, newRange=%s".format(lastRecord, currentRange, tokenRanges.head))
-              tokenRanges.head
-            }
+            case Some(range) => range.nextRange(tokenRanges).getOrElse(tokenRanges.head)
+            case None => tokenRanges.head
           }
         }
       }
       currentRange = Some(loadRange)
 
-      // The loadRecords method may returns the "from" record, we remove it first. TODO: should this be done in loadRecords?
+      // The loadRecords method may returns the "from" record, we remove it first.
       val records = lastRecord match {
         case Some(record) => loadRecords(loadRange, lastRecord).filterNot(_ == record)
         case None => loadRecords(loadRange, lastRecord)

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableTimelineFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableTimelineFeeder.scala
@@ -11,9 +11,9 @@ import com.wajam.nrv.service.TokenRange
 /**
  * Table mutation timeline task feeder
  */
-class TableTimelineFeeder(name: String, storage: MysqlStorage, table: Table, tokenRanges: List[TokenRange],
+class TableTimelineFeeder(val name: String, storage: MysqlStorage, table: Table, tokenRanges: List[TokenRange],
                           val batchSize: Int = 100)
-  extends CachedDataFeeder(name) with CurrentTime with Logging {
+  extends CachedDataFeeder with CurrentTime with Logging {
 
   private val contextTimestampGauge = metrics.gauge("context-timestamp", name) {
     val contexts = TimelineFeederContextCache.contexts(name)


### PR DESCRIPTION
TableContinuousFeeder has been rewritten and split in two: a TableContinuousFeeder mixable trait and TableAllLatestFeeder which load the data. 

Use the two together to have the same functionality as before: <code>new TableAllLatestFeeder(...) with TableContinuousFeeder</code>
