### PR TITLE
Fix TableAllLatestFeeder when deleted records range > loadLimit

### DIFF
--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/FeederTestHelper.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/FeederTestHelper.scala
@@ -1,0 +1,17 @@
+package com.wajam.mry.storage.mysql
+
+import com.wajam.nrv.utils.Closable
+import com.wajam.spnl.feeder.Feeder
+
+object FeederTestHelper {
+  implicit def feederToIterator(feeder: Feeder): Iterator[Option[Map[String, Any]]] with Closable = {
+
+    new Iterator[Option[Map[String, Any]]] with Closable {
+      def hasNext = true
+
+      def next() = feeder.next()
+
+      def close() = feeder.kill()
+    }
+  }
+}

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -1104,15 +1104,17 @@ class TestMysqlStorage extends TestMysqlBase with ShouldMatchers {
       val t1 = t.from("mysql").from("table1")
       deletedKeys.foreach(tup => t1.delete(tup._2))
       createdKeys.foreach(tup => t1.set(tup._2, Map(tup._2 -> tup._2)))
-    }, commit = true)
+    }, commit = true, onTimestamp = createTimestamp(0))
 
     var recordsExcludeDeleted = mysqlStorage.createStorageTransaction(context).getAllLatest(table1, 50).toList
-    recordsExcludeDeleted.size should be(createdKeys.size)
 
     var recordsIncludeDeleted = mysqlStorage.createStorageTransaction(context).getAllLatest(table1, 50, includeDeleted = true).toList
-    recordsIncludeDeleted.size should be(keys.size)
 
     val recordsDeleted = recordsIncludeDeleted.filter(_.value == NullValue)
+    println("%d, %d, %d".format(recordsExcludeDeleted.size, recordsIncludeDeleted.size, recordsDeleted.size))
+
+    recordsExcludeDeleted.size should be(createdKeys.size)
+    recordsIncludeDeleted.size should be(keys.size)
     recordsDeleted.size should be(deletedKeys.size)
   }
 

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -1112,7 +1112,7 @@ class TestMysqlStorage extends TestMysqlBase with ShouldMatchers {
     var recordsIncludeDeleted = mysqlStorage.createStorageTransaction(context).getAllLatest(table1, 50, includeDeleted = true).toList
     recordsIncludeDeleted.size should be(keys.size)
 
-    val recordsDeleted = recordsIncludeDeleted.filter(_.value == NullValue)
+    val recordsDeleted = recordsIncludeDeleted.filter(_.value.isNull)
     recordsDeleted.size should be(deletedKeys.size)
   }
 

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -1107,14 +1107,12 @@ class TestMysqlStorage extends TestMysqlBase with ShouldMatchers {
     }, commit = true, onTimestamp = createTimestamp(0))
 
     var recordsExcludeDeleted = mysqlStorage.createStorageTransaction(context).getAllLatest(table1, 50).toList
+    recordsExcludeDeleted.size should be(createdKeys.size)
 
     var recordsIncludeDeleted = mysqlStorage.createStorageTransaction(context).getAllLatest(table1, 50, includeDeleted = true).toList
+    recordsIncludeDeleted.size should be(keys.size)
 
     val recordsDeleted = recordsIncludeDeleted.filter(_.value == NullValue)
-    println("%d, %d, %d".format(recordsExcludeDeleted.size, recordsIncludeDeleted.size, recordsDeleted.size))
-
-    recordsExcludeDeleted.size should be(createdKeys.size)
-    recordsIncludeDeleted.size should be(keys.size)
     recordsDeleted.size should be(deletedKeys.size)
   }
 

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -1090,6 +1090,32 @@ class TestMysqlStorage extends TestMysqlBase with ShouldMatchers {
     recordsKey should be(keys.map(_._2).slice(19, 39).toList)
   }
 
+  test("getAllLatest should support deleted records") {
+    val context = new ExecutionContext(storages)
+    val keys = Seq.range(0, 40).map(i => {
+      val key = "key%d".format(i)
+      (context.getToken(key), key)
+    }).sorted
+
+    val deletedKeys = keys.filter(_._1 % 2 == 0)
+    val createdKeys = keys.filter(_._1 % 2 != 0)
+
+    exec(t => {
+      val t1 = t.from("mysql").from("table1")
+      deletedKeys.foreach(tup => t1.delete(tup._2))
+      createdKeys.foreach(tup => t1.set(tup._2, Map(tup._2 -> tup._2)))
+    }, commit = true)
+
+    var recordsExcludeDeleted = mysqlStorage.createStorageTransaction(context).getAllLatest(table1, 50).toList
+    recordsExcludeDeleted.size should be(createdKeys.size)
+
+    var recordsIncludeDeleted = mysqlStorage.createStorageTransaction(context).getAllLatest(table1, 50, includeDeleted = true).toList
+    recordsIncludeDeleted.size should be(keys.size)
+
+    val recordsDeleted = recordsIncludeDeleted.filter(_.value == NullValue)
+    recordsDeleted.size should be(deletedKeys.size)
+  }
+
   test("getAllLatest with token range") {
     val context = new ExecutionContext(storages)
     val keys = Seq.range(0, 40).map(i => {

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
@@ -234,14 +234,14 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
 
     // Delete all records for every 1 token out of 2
     val (deleted, survivors) = allRecords.groupBy(_.token).partition(_._1 % 2 == 0)
-    deleted.flatMap(_._2).foreach(delete)
+    deleted.values.flatten.foreach(delete)
 
     // Purge feeder potentially cached records now deleted
     feeder.take(50).toList
 
     // Verify each non deleted record is read more than once (i.e. continuous started over)
     val afterRecords = feeder.take(100).flatten.map(feeder.toRecord(_).get).toList.groupBy(r => r)
-    afterRecords.keySet should be(survivors.flatMap(_._2).toSet)
-    afterRecords.foreach(_._2.size should be > 1)
+    afterRecords.keySet should be(survivors.values.flatten.toSet)
+    afterRecords.values.forall(_.size > 1) should be(true)
   }
 }

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
@@ -239,8 +239,6 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     // Purge feeder potentially cached records now deleted
     feeder.take(50).toList
 
-    println(survivors.map(_._1))
-
     // Verify each non deleted record is read more than once (i.e. continuous started over)
     val afterRecords = feeder.take(100).flatten.map(feeder.toRecord(_).get).toList.groupBy(r => r)
     afterRecords.keySet should be(survivors.flatMap(_._2).toSet)

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
@@ -211,7 +211,6 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     }
 
     def delete(record: Record) {
-//      println(s"delete: record=$record")
       val transaction = mysqlStorage.createStorageTransaction
       try {
         transaction.set(table1_1_1, record.token, record.timestamp, record.accessPath, None)
@@ -245,7 +244,6 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     // Verify each non deleted record is read more than once (i.e. continuous started over)
     val afterRecords = feeder.take(100).flatten.map(feeder.toRecord(_).get).toList.groupBy(r => r)
     afterRecords.keySet should be(survivors.flatMap(_._2).toSet)
-//    afterRecords.map(_._1).foreach(r => survivors(r.token).contains(r) should be(true))
     afterRecords.foreach(_._2.size should be > 1)
   }
 }

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
@@ -144,7 +144,7 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     val context2 = new TaskContext()
     context2.updateFromJson(feeder1.context.toJson)
     feeder2.init(context2)
-    var records2 = feeder2.take(10).flatten.toList
+    val records2 = feeder2.take(10).flatten.toList
 
     records2.size should be(9)
     records2.map(_(Token)) should be(keys.slice(records.length, records.length + records2.length).map(_._1.toString))

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
@@ -8,11 +8,13 @@ import com.wajam.spnl.TaskContext
 import com.wajam.mry.storage.mysql.TableAllLatestFeeder._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
+import com.wajam.mry.storage.StorageException
+import scala.collection.immutable.Iterable
 
 @RunWith(classOf[JUnitRunner])
 class TestTableAllLatestFeeder extends TestMysqlBase {
 
-  test("continuous feeder should feed in loop a table and in token+key order") {
+  test("feeder should feed in loop a table and in token+key order") {
     val context = new ExecutionContext(storages)
     val keys = List.range(0, 20).map(i => {
       val key = "key%d".format(i)
@@ -26,9 +28,7 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
 
 
     val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1, TokenRange.All) with TableContinuousFeeder
-    val records = Iterator.continually({
-      feeder.next()
-    }).take(100).flatten.toList
+    val records = feeder.take(100).flatten.toList
 
     // 91 = 100 - (5 loadMore + 4 end of records)
     records.size should be(91)
@@ -60,9 +60,7 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     feederContext.data += (Keys -> Seq(keys(5)._2))
     feederContext.data += (Timestamp -> createTimestamp(5))
     feeder.init(feederContext)
-    val records = Iterator.continually({
-      feeder.next()
-    }).take(10).flatten.toList
+    val records = feeder.take(10).flatten.toList
 
     records(0)(Token) should be(keys(6)._1.toString)
   }
@@ -88,9 +86,7 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     feederContext.data += (Keys -> Seq(keys(5)._2))
     feederContext.data += (Timestamp -> "abc") // Invalid timestamp
     feeder.init(feederContext)
-    val records = Iterator.continually({
-      feeder.next()
-    }).take(10).flatten.toList
+    val records = feeder.take(10).flatten.toList
 
     records(0)(Token) should be(keys(0)._1.toString)
   }
@@ -112,9 +108,7 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     // Should load records from start
     val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1, TokenRange.All) with TableContinuousFeeder
     feeder.init(new TaskContext())
-    val records = Iterator.continually({
-      feeder.next()
-    }).take(10).flatten.toList
+    val records = feeder.take(10).flatten.toList
 
     records(0)(Token) should be(keys(0)._1.toString)
   }
@@ -137,9 +131,7 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     // Load some records
     val feeder1 = new TableAllLatestFeeder("test", mysqlStorage, table1_1, TokenRange.All) with TableContinuousFeeder
     feeder1.init(new TaskContext())
-    val records = Iterator.continually({
-      feeder1.next()
-    }).take(10).flatten.toList
+    val records = feeder1.take(10).flatten.toList
 
     records.size should be(9)
     records.map(_(Token)) should be(keys.slice(0, records.length).map(_._1.toString))
@@ -152,15 +144,13 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     val context2 = new TaskContext()
     context2.updateFromJson(feeder1.context.toJson)
     feeder2.init(context2)
-    var records2 = Iterator.continually({
-      feeder2.next()
-    }).take(10).flatten.toList
+    var records2 = feeder2.take(10).flatten.toList
 
     records2.size should be(9)
     records2.map(_(Token)) should be(keys.slice(records.length, records.length + records2.length).map(_._1.toString))
   }
 
-  test("continuous feeder should feed in loop a table and in token+key order for ranges") {
+  test("feeder should iterate a table and in token+key order for ranges") {
     val context = new ExecutionContext(storages)
     val keys = List.range(0, 20).map(i => {
       val key = "key%d".format(i)
@@ -176,9 +166,7 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     val expectedKeys = keys.filter(k => ranges.exists(_.contains(k._1))).toList
 
     val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1, ranges, loadLimit = 3) with TableContinuousFeeder
-    val records = Iterator.continually({
-      feeder.next()
-    }).take(100).flatten.toList
+    val records = feeder.take(100).flatten.toList
 
     val expectedTokens = Stream.continually(expectedKeys.map(_._1)).flatten
     val actualTokens = records.map(_(Token).toString.toLong)
@@ -199,14 +187,65 @@ class TestTableAllLatestFeeder extends TestMysqlBase {
     currentConsistentTimestamp = 50L
 
     val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1, TokenRange.All) with TableContinuousFeeder
-    val records = Iterator.continually({
-      feeder.next()
-    }).take(100).flatten.toList
+    val records = feeder.take(100).flatten.toList
 
     records.size should be > 0
     val strKeys = records.map(_(Keys).asInstanceOf[Seq[String]](0))
     strKeys.count(_ == "key1") should be(records.size)
     strKeys.count(_ == "key2") should be(0)
+  }
 
+  test("should not stop prematurely when iterating over many consecutive deleted records") {
+
+    def create(index: Int, count: Int) {
+      exec(t => {
+        val storage = t.from("mysql")
+        val table = storage.from("table1")
+        table.set(s"key$index", Map("k" -> s"value$index"))
+        table.get(s"key$index").from("table1_1").set(s"key$index.1", Map("k" -> s"value$index.1"))
+        table.get(s"key$index").from("table1_1").set(s"key$index.2", Map("k" -> s"value$index.2"))
+        for (i <- 1 to count) {
+          table.get(s"key$index").from("table1_1").get(s"key$index.1").from("table1_1_1").set(s"key$index.$index.$i", Map("k" -> s"value3.$index.$i"))
+        }
+      }, commit = true)
+    }
+
+    def delete(record: Record) {
+//      println(s"delete: record=$record")
+      val transaction = mysqlStorage.createStorageTransaction
+      try {
+        transaction.set(table1_1_1, record.token, record.timestamp, record.accessPath, None)
+      } finally {
+        transaction.commit()
+      }
+    }
+
+    create(1, count = 6)
+    create(2, count = 6)
+    create(3, count = 6)
+    create(4, count = 6)
+    create(5, count = 6)
+    create(6, count = 6)
+    create(7, count = 6)
+    create(8, count = 6)
+    create(9, count = 6)
+
+    val feeder = new TableAllLatestFeeder("test", mysqlStorage, table1_1_1, TokenRange.All, loadLimit = 3) with TableContinuousFeeder
+    val allRecords = feeder.take(100).flatten.map(feeder.toRecord(_).get).toList
+
+    // Delete all records for every 1 token out of 2
+    val (deleted, survivors) = allRecords.groupBy(_.token).partition(_._1 % 2 == 0)
+    deleted.flatMap(_._2).foreach(delete)
+
+    // Purge feeder potentially cached records now deleted
+    feeder.take(50).toList
+
+    println(survivors.map(_._1))
+
+    // Verify each non deleted record is read more than once (i.e. continuous started over)
+    val afterRecords = feeder.take(100).flatten.map(feeder.toRecord(_).get).toList.groupBy(r => r)
+    afterRecords.keySet should be(survivors.flatMap(_._2).toSet)
+//    afterRecords.map(_._1).foreach(r => survivors(r.token).contains(r) should be(true))
+    afterRecords.foreach(_._2.size should be > 1)
   }
 }

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableAllLatestFeeder.scala
@@ -8,8 +8,7 @@ import com.wajam.spnl.TaskContext
 import com.wajam.mry.storage.mysql.TableAllLatestFeeder._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import com.wajam.mry.storage.StorageException
-import scala.collection.immutable.Iterable
+import com.wajam.mry.storage.mysql.FeederTestHelper._
 
 @RunWith(classOf[JUnitRunner])
 class TestTableAllLatestFeeder extends TestMysqlBase {

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableContinuousFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableContinuousFeeder.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.ShouldMatchers._
 import com.wajam.nrv.service.{TokenRangeSeq, TokenRange}
 import com.wajam.spnl.TaskContext
 import org.mockito.Mockito._
+import com.wajam.mry.storage.mysql.FeederTestHelper._
 
 @RunWith(classOf[JUnitRunner])
 class TestTableContinuousFeeder extends FunSuite {

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableTimelineFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableTimelineFeeder.scala
@@ -6,6 +6,7 @@ import com.wajam.spnl.TaskContext
 import com.wajam.nrv.service.TokenRange
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
+import com.wajam.mry.storage.mysql.FeederTestHelper._
 
 @RunWith(classOf[JUnitRunner])
 class TestTableTimelineFeeder extends TestMysqlBase {

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableTimelineFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableTimelineFeeder.scala
@@ -41,9 +41,7 @@ class TestTableTimelineFeeder extends TestMysqlBase {
 
     val feeder = new TableTimelineFeeder("test", mysqlStorage, table1, List(TokenRange.All), batchSize)
     feeder.init(new TaskContext())
-    val records = Iterator.continually({
-      feeder.next()
-    }).take(100).flatten.toList.map(_("new_timestamp").toString.toLong)
+    val records = feeder.take(100).flatten.toList.map(_("new_timestamp").toString.toLong)
 
     records.size should be(70)
     records should be(records.sorted)
@@ -74,9 +72,7 @@ class TestTableTimelineFeeder extends TestMysqlBase {
 
     val feeder = new TableTimelineFeeder("test", mysqlStorage, table1, List(TokenRange.All), batchSize)
     feeder.init(new TaskContext())
-    val records = Iterator.continually({
-      feeder.next()
-    }).take(100).flatten.toList.map(_("new_timestamp").toString.toLong)
+    val records = feeder.take(100).flatten.toList.map(_("new_timestamp").toString.toLong)
 
     records.size should be(20)
     records should be(records.sorted)
@@ -97,9 +93,7 @@ class TestTableTimelineFeeder extends TestMysqlBase {
 
     val feeder = new TableTimelineFeeder("test", mysqlStorage, table1, ranges, batchSize)
     feeder.init(new TaskContext())
-    val records = Iterator.continually({
-      feeder.next()
-    }).take(100).flatten.toList
+    val records = feeder.take(100).flatten.toList
 
     records.size should be > 0
     records.size should be < 40
@@ -125,9 +119,7 @@ class TestTableTimelineFeeder extends TestMysqlBase {
     // Load all existing records
     val feeder1 = new TableTimelineFeeder("test", mysqlStorage, table1, List(TokenRange.All))
     feeder1.init(new TaskContext())
-    var records1 = Iterator.continually({
-      feeder1.next()
-    }).take(100).flatten.toList
+    var records1 = feeder1.take(100).flatten.toList
     records1.size should be(5)
 
     // Acknowledge the first record
@@ -224,9 +216,7 @@ class TestTableTimelineFeeder extends TestMysqlBase {
 
     val feeder = new TableTimelineFeeder("test", mysqlStorage, table1, List(TokenRange.All))
     feeder.init(new TaskContext())
-    val records = Iterator.continually({
-      feeder.next()
-    }).take(100).flatten.toList
+    val records = feeder.take(100).flatten.toList
 
     records.size should be > 0
     val strKeys = records.map(_("keys").asInstanceOf[Seq[String]](0))

--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableTombstoneFeeder.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestTableTombstoneFeeder.scala
@@ -82,8 +82,8 @@ class TestTableTombstoneFeeder extends TestMysqlBase {
     key2First3.map(_.accessPath.keys.last) should be(Seq("key2.1a", "key2.1b", "key2.1c"))
 
     val key2Reminder = limitedFeeder.loadRecords(TokenRange.All, Some(key2First3.last))
-    key2Reminder.size should be(2)
-    key2Reminder.map(_.accessPath.keys.last) should be(Seq("key2.1c", "key2.1d"))
+    key2Reminder.size should be(1)
+    key2Reminder.map(_.accessPath.keys.last) should be(Seq("key2.1d"))
   }
 
 }

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/RecordDataFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/RecordDataFeeder.scala
@@ -32,4 +32,13 @@ trait ResumableRecordDataFeeder extends RecordDataFeeder {
     })
   }
 
+  /**
+   * Filter out the specified start record from the records collection
+   */
+  protected def filterStartRecord(records: Iterable[DataRecord], startAfterRecord: Option[DataRecord]): Iterable[DataRecord] = {
+    startAfterRecord match {
+      case Some(startRecord) => records.filter(_ != startRecord)
+      case None => records
+    }
+  }
 }

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/RecordDataFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/RecordDataFeeder.scala
@@ -19,7 +19,7 @@ trait ResumableRecordDataFeeder extends RecordDataFeeder {
 
   def token(record: DataRecord): Long
 
-  def loadRecords(range: TokenRange, fromRecord: Option[DataRecord]): Iterable[DataRecord]
+  def loadRecords(range: TokenRange, startAfterRecord: Option[DataRecord]): Iterable[DataRecord]
 
   def toContextData(data: Map[String, Any]): Map[String, Any] = data
 

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
@@ -26,7 +26,6 @@ abstract class TableAllLatestFeeder(val name: String, storage: MysqlStorage, tab
         case None => records.toList
       }
       if (filteredRecords.nonEmpty) {
-        println(s"loadRecords: OK, $filteredRecords")
         filteredRecords
       } else {
         loadFirstNonDeletedRecords(range, startAfterRecord)
@@ -44,7 +43,6 @@ abstract class TableAllLatestFeeder(val name: String, storage: MysqlStorage, tab
       case Some(startRecord) => records.filter(_ != startRecord).toList
       case None => records.toList
     }
-    println(s"loadFirstNonDeletedRecords: $filteredRecords")
     filteredRecords.collectFirst{case record if record.value != NullValue => record} match {
       case record@Some(_) => record
       case None if filteredRecords.isEmpty => None

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
@@ -1,7 +1,6 @@
 package com.wajam.mry.storage.mysql
 
 import com.wajam.nrv.Logging
-import com.wajam.spnl.feeder.CachedDataFeeder
 import com.wajam.nrv.service.{TokenRangeSeq, TokenRange}
 import com.wajam.mry.execution.{NullValue, Value}
 import scala.annotation.tailrec

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableAllLatestFeeder.scala
@@ -44,7 +44,7 @@ abstract class TableAllLatestFeeder(val name: String, storage: MysqlStorage, tab
       None
     } else {
       // Returns first non deleted record or continue further
-      records.collectFirst{case record if record.value != NullValue => record} match {
+      records.collectFirst{case record if !record.value.isNull => record} match {
         case record@Some(_) => record
         case None => loadFirstNonDeletedRecords(range, records.lastOption)
       }

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableContinuousFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableContinuousFeeder.scala
@@ -32,10 +32,8 @@ trait TableContinuousFeeder extends CachedDataFeeder with ResumableRecordDataFee
       val (loadRange, startRecord) = getLoadPosition
 
       // Filter out the "from" records in case it is returned by the load method
-      val records = startRecord match {
-        case Some(record) => loadRecords(loadRange, startRecord).filterNot(_ == record)
-        case None => loadRecords(loadRange, startRecord)
-      }
+      val records = filterStartRecord(loadRecords(loadRange, startRecord), startRecord)
+
       currentRange = Some(loadRange)
       lastRecord = records.lastOption
 

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableTombstoneFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableTombstoneFeeder.scala
@@ -17,11 +17,7 @@ abstract class TableTombstoneFeeder(val name: String, storage: MysqlStorage, tab
   def loadRecords(range: TokenRange, startAfterRecord: Option[TombstoneRecord]): Iterable[TombstoneRecord] = {
     val transaction = storage.createStorageTransaction
     try {
-      val records = transaction.getTombstoneRecords(table, loadLimit, range, minTombstoneAge, startAfterRecord)
-      startAfterRecord match {
-        case Some(startRecord) => records.filter(_ != startRecord)
-        case None => records
-      }
+      filterStartRecord(transaction.getTombstoneRecords(table, loadLimit, range, minTombstoneAge, startAfterRecord), startAfterRecord)
     } finally {
       transaction.commit()
     }

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableTombstoneFeeder.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/TableTombstoneFeeder.scala
@@ -14,10 +14,14 @@ abstract class TableTombstoneFeeder(val name: String, storage: MysqlStorage, tab
 
   type DataRecord = TombstoneRecord
 
-  def loadRecords(range: TokenRange, fromRecord: Option[TombstoneRecord]): Iterable[TombstoneRecord] = {
+  def loadRecords(range: TokenRange, startAfterRecord: Option[TombstoneRecord]): Iterable[TombstoneRecord] = {
     val transaction = storage.createStorageTransaction
     try {
-      transaction.getTombstoneRecords(table, loadLimit, range, minTombstoneAge, fromRecord)
+      val records = transaction.getTombstoneRecords(table, loadLimit, range, minTombstoneAge, startAfterRecord)
+      startAfterRecord match {
+        case Some(startRecord) => records.filter(_ != startRecord)
+        case None => records
+      }
     } finally {
       transaction.commit()
     }


### PR DESCRIPTION
TableAllLatestFeeder wasn't iterating over the complete table when deleted records range was > loadLimit.
