### PR TITLE
Optimize synthetic deleted generated when replicating from storage

### DIFF
--- a/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
+++ b/mry-core/src/it/scala/com/wajam/mry/storage/mysql/TestMysqlStorage.scala
@@ -1582,9 +1582,14 @@ class TestMysqlStorage extends TestMysqlBase with ShouldMatchers {
 
     CompositeKey("abc", "0", "1", "2", "3").head should be(CompositeKey("abc"))
     CompositeKey("abc", "0", "1", "2", "3").parent should be(CompositeKey("abc", "0", "1", "2"))
+    CompositeKey("abc", "0").ancestors should be(List(CompositeKey("abc")))
+    CompositeKey("abc").ancestors should be(Nil)
+    CompositeKey(Seq[String]():_*).ancestors should be(Nil)
 
     CompositeKey(table1_1_1, "0", "1", "2").head should be(CompositeKey(table1, "0"))
     CompositeKey(table1_1_1, "0", "1", "2").parent should be(CompositeKey(table1_1, "0", "1"))
+    CompositeKey(table1_1_1, "0", "1", "2").ancestors should be(List(CompositeKey(table1_1, "0", "1"), CompositeKey(table1, "0")))
+    CompositeKey(table1, "0").ancestors should be(Nil)
   }
 
   test("test composite key subset") {
@@ -1592,11 +1597,14 @@ class TestMysqlStorage extends TestMysqlBase with ShouldMatchers {
     import java.util
     
     val set = new util.TreeSet(
-      List(CompositeKey(table2_1, "2", "1"), CompositeKey(table1, "9"), CompositeKey(table1, "0")))
-    set.toList should be(List(CompositeKey(table1, "0"), CompositeKey(table1, "9"), CompositeKey(table2_1, "2", "1")))
+      List(CompositeKey(table2_1, "2", "1"), CompositeKey(table1, "9"),
+        CompositeKey(table1, "0"), CompositeKey(table1_1, "0", "0")))
+    set.toList should be(List(
+      CompositeKey(table1, "0"), CompositeKey(table1_1, "0", "0"),
+      CompositeKey(table1, "9"), CompositeKey(table2_1, "2", "1")))
 
     val k1 = CompositeKey(table1_1_1, "0", "1", "2")
-    set.subSet(k1.head, true, k1.parent, true).toList should be(List(CompositeKey(table1, "0")))
+    set.subSet(k1.head, true, k1.parent, true).toList should be(List(CompositeKey(table1, "0"), CompositeKey(table1_1, "0", "0")))
 
     val k2 = CompositeKey(table2_1_1, "2", "1", "0")
     set.subSet(k2.head, true, k2.parent, true).toList should be(List(CompositeKey(table2_1, "2", "1")))

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlStorage.scala
@@ -1,7 +1,6 @@
 package com.wajam.mry.storage.mysql
 
 import com.mchange.v2.c3p0.ComboPooledDataSource
-import com.wajam.nrv.Logging
 import java.sql.{PreparedStatement, ResultSet, SQLException, Connection}
 import com.wajam.mry.execution._
 import com.wajam.mry.api.protobuf.ProtobufTranslator
@@ -13,7 +12,7 @@ import java.util.concurrent.{TimeUnit, ScheduledThreadPoolExecutor}
 import com.wajam.nrv.service.TokenRange
 import com.yammer.metrics.core.Gauge
 import annotation.tailrec
-import com.wajam.commons.Closable
+import com.wajam.commons.{Logging, Closable}
 import com.wajam.nrv.utils.timestamp.Timestamp
 
 /**
@@ -393,14 +392,21 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
      */
     def applyTo(transaction: Transaction) {
       import com.wajam.mry.execution.Implicits._
+      import java.util
 
       // Set or delete each record
       val storage = transaction.from("mysql")
+      val deleted: util.NavigableSet[CompositeKey[(String, String)]] = new util.TreeSet()
       for (record <- records.sortBy(_.table.depth)) {
         val tableNames = record.table.path.map(_.name)
         val keys = record.accessPath.keys
         if (record.value.isNull) {
-          storage.from(tableNames).delete(keys)
+          // Delete record only if parent record not previously deleted in the same transaction
+          val deleteKey = CompositeKey(record)
+          if (keys.size == 1 || deleted.subSet(deleteKey.head, true, deleteKey.parent, true).isEmpty) {
+            storage.from(tableNames).delete(keys)
+            deleted.add(deleteKey)
+          }
         } else {
           storage.from(tableNames).set(keys, record.value)
         }
@@ -419,8 +425,8 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
    * @param endTimestamp end timestamp (inclusive)
    * @param ranges token ranges
    * @param recordsCacheSize maximum number of records cached in this iterator. This is not the mutation group size but
-   *                        the number of records contained in the queued mutation group. A limit of 100 records can be
-   *                        reach by having 4 mutation groups of 25 records.
+   *                         the number of records contained in the queued mutation group. A limit of 100 records can be
+   *                         reach by having 4 mutation groups of 25 records.
    * @param tableSummarySize number of transaction summary records loaded per table per call from database
    * @param tableSummaryThreshold threshold per table below which more transaction summary records are loaded
    */
@@ -454,7 +460,7 @@ class MysqlStorage(config: MysqlStorageConfiguration, garbageCollection: Boolean
     // Transaction summary cached per table.
     private val tablesCache: Seq[TableSummary] = {
       model.allHierarchyTables.map(table => {
-        val initialTimestamp = Timestamp(findInitialTableTimestamp(table) -1)
+        val initialTimestamp = Timestamp(findInitialTableTimestamp(table) - 1)
         loadTableSummary(TableSummary(table, initialTimestamp))
       }).toSeq
     }

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
@@ -958,6 +958,14 @@ case class CompositeKey[T](keys: T*)(implicit ord: math.Ordering[T]) extends Com
   def head = CompositeKey(keys.head)
 
   def parent = CompositeKey(keys.dropRight(1): _*)
+
+  def ancestors: List[CompositeKey[T]] = {
+    if (keys.size > 1) {
+      parent :: parent.ancestors
+    } else {
+      Nil
+    }
+  }
 }
 
 object CompositeKey {

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/MysqlTransaction.scala
@@ -952,6 +952,25 @@ class MutationRecord {
   }
 }
 
+case class CompositeKey[T](keys: T*)(implicit ord: math.Ordering[T]) extends Comparable[CompositeKey[T]] {
+  def compareTo(that: CompositeKey[T]) = math.Ordering.Iterable[T].compare(keys, that.keys)
+
+  def head = CompositeKey(keys.head)
+
+  def parent = CompositeKey(keys.dropRight(1): _*)
+}
+
+object CompositeKey {
+  def apply(table: Table, keys: String*): CompositeKey[(String, String)] = {
+    require(table.path.size == keys.size)
+    new CompositeKey(table.path.map(_.name).zip(keys): _*)
+  }
+
+  def apply(record: Record): CompositeKey[(String, String)] = {
+    CompositeKey(record.table, record.accessPath.keys: _*)
+  }
+}
+
 class RecordIterator(storage: MysqlStorage, results: SqlResults, table: Table) extends Traversable[Record] {
   private var hasNext = false
   private var closed = false


### PR DESCRIPTION
Do not generate child record delete when parent is deleted in the same transaction.
