### PR TITLE
Disable cache for slave member

### DIFF
--- a/mry-core/src/main/scala/com/wajam/mry/ConsistentDatabase.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/ConsistentDatabase.scala
@@ -27,6 +27,8 @@ trait ConsistentDatabase extends ConsistentStore with Instrumented {
     case storage: ConsistentStorage => storage
   }
 
+  def invalidateCache() = consistentStorages.foreach(_.invalidateCache())
+
   def requiresConsistency(message: Message): Boolean = {
     if (consistentStorages.nonEmpty) {
       findAction(message.path, message.method) match {
@@ -120,6 +122,7 @@ trait ConsistentDatabase extends ConsistentStore with Instrumented {
       val timestamp = message.timestamp
       val context = new ExecutionContext(storages, timestamp)
       context.cluster = cluster
+      context.cacheAllowed = false
 
       try {
         transaction.execute(context)

--- a/mry-core/src/main/scala/com/wajam/mry/execution/ExecutionContext.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/execution/ExecutionContext.scala
@@ -15,6 +15,7 @@ class ExecutionContext(var storages: Map[String, Storage], val timestamp: Option
   var isMutation: Boolean = false
   var tokens: List[Long] = List()
   var cluster: Cluster = null
+  var cacheAllowed: Boolean = true
 
   var storageTransactions = Map[Storage, StorageTransaction]()
   var returnValues: Seq[Value] = Seq()

--- a/mry-core/src/main/scala/com/wajam/mry/storage/ConsistentStorage.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/ConsistentStorage.scala
@@ -11,6 +11,11 @@ import com.wajam.nrv.utils.timestamp.Timestamp
 trait ConsistentStorage extends Storage {
 
   /**
+   * Force invalidation of the storage cache.
+   */
+  def invalidateCache()
+
+  /**
    * Returns the latest record timestamp for the specified token ranges
    */
   def getLastTimestamp(ranges: Seq[TokenRange]): Option[Timestamp]

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/cache/HierarchicalCache.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/cache/HierarchicalCache.scala
@@ -16,6 +16,8 @@ class HierarchicalCache(model: => Model, expireMs: Long, maximumSizePerTable: In
    */
   def createTransactionCache = new TransactionCache(getTopLevelTableCache)
 
+  def invalidateAll(): Unit = tableCaches.valuesIterator.foreach(_.invalidateAll())
+
   private def getTopLevelTableCache(table: Table): HierarchicalTableCache = tableCaches(table.getTopLevelTable)
 }
 
@@ -44,6 +46,11 @@ class HierarchicalTableCache(expireMs: Long, maximumSize: Int) extends TableCach
     invalidateDescendants(path)
     keys.remove(path)
     cache.invalidate(path)
+  }
+
+  def invalidateAll() = {
+    cache.invalidateAll()
+    keys.clear()
   }
 
   private def invalidateDescendants(path: AccessPath): Unit = {

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/cache/TableCache.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/cache/TableCache.scala
@@ -12,4 +12,6 @@ trait TableCache[V] {
   def put(key: AccessPath, record: V): Unit
 
   def invalidate(key: AccessPath): Unit
+
+  def invalidateAll(): Unit
 }

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/cache/TableCache.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/cache/TableCache.scala
@@ -12,6 +12,8 @@ trait TableCache[V] {
   def put(key: AccessPath, record: V): Unit
 
   def invalidate(key: AccessPath): Unit
+}
 
+trait ResettableTableCache[V] extends TableCache[V] {
   def invalidateAll(): Unit
 }

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/cache/TransactionCache.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/cache/TransactionCache.scala
@@ -121,8 +121,6 @@ class TransactionCache(metrics: CacheMetrics, getTableCache: (Table) => TableCac
 
     def invalidate(path: AccessPath) = cache.remove(path)
 
-    def invalidateAll() = throw new NotImplementedError
-
     def toIterable: Iterable[(AccessPath, CachedValue)] = {
       import collection.JavaConversions._
       cache.entrySet().toIterator.toIterable.map(e => e.getKey -> e.getValue)

--- a/mry-core/src/main/scala/com/wajam/mry/storage/mysql/cache/TransactionCache.scala
+++ b/mry-core/src/main/scala/com/wajam/mry/storage/mysql/cache/TransactionCache.scala
@@ -100,6 +100,8 @@ class TransactionCache(getTableCache: (Table) => TableCache[Record]) extends Log
 
     def invalidate(path: AccessPath) = cache.remove(path)
 
+    def invalidateAll() = throw new NotImplementedError
+
     def toIterable: Iterable[(AccessPath, CachedValue)] = {
       import collection.JavaConversions._
       cache.entrySet().toIterator.toIterable.map(e => e.getKey -> e.getValue)
@@ -145,4 +147,3 @@ object TransactionCache {
   case class CachedValue(record: Option[Record], action: Action)
 
 }
-

--- a/mry-core/src/test/scala/com/wajam/mry/storage/mysql/cache/TestHierarchicalTableCache.scala
+++ b/mry-core/src/test/scala/com/wajam/mry/storage/mysql/cache/TestHierarchicalTableCache.scala
@@ -7,96 +7,132 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
+import com.wajam.mry.storage.mysql.{Record, Table}
 
 @RunWith(classOf[JUnitRunner])
 class TestHierarchicalTableCache extends FlatSpec {
 
-  "HierarchicalTableCache" should "cache all values" in new CacheSetup {
-    val cache = new HierarchicalTableCache(table1, new CacheMetrics {}, 1000, 200)
+  "HierarchicalTableCache" should behave like tableCacheBehavior(newHierarchicalTableCache)
+  "ResettableHierarchicalTableCache" should behave like tableCacheBehavior(newResettableHierarchicalTableCache)
+  it should behave like resettableTableCacheBehavior(newResettableHierarchicalTableCache)
 
-    // Cache all records and verify their presence/value
-    all.foreach { r => cache.getIfPresent(r.accessPath) should be(None)}
-    all.foreach(r => cache.put(r.accessPath, r))
-    all.foreach { r => cache.getIfPresent(r.accessPath) should be(Some(r))}
-
-    // Update one leaf value and verify cache is updated
-    cache.getIfPresent(b_a_a.accessPath) should be(Some(b_a_a))
-    val b_a_a2 = record(b_a_a.table, b_a_a.accessPath, "2")
-    cache.put(b_a_a2.accessPath, b_a_a2)
-    cache.getIfPresent(b_a_a.accessPath) should be(Some(b_a_a2))
+  def newHierarchicalTableCache(table: Table, metrics: CacheMetrics, expireMs: Long, maximumSize: Int) = {
+    new HierarchicalTableCache(table, metrics, expireMs, maximumSize)
   }
 
-  it should "update should NOT invalidate children" in new CacheSetup {
-    val cache = new HierarchicalTableCache(table1, new CacheMetrics {}, 1000, 200)
-
-    // Cache all records and verify their presence/value
-    all.foreach { r => cache.getIfPresent(r.accessPath) should be(None)}
-    all.foreach(r => cache.put(r.accessPath, r))
-    all.foreach { r => cache.getIfPresent(r.accessPath) should be(Some(r))}
-
-    // Update one value and verify cache is updated and children NOT invalidated
-    cache.getIfPresent(a.accessPath) should be(Some(a))
-    val a2 = record(a.table, a.accessPath, "2")
-    cache.put(a2.accessPath, a2)
-    cache.getIfPresent(a.accessPath) should be(Some(a2))
-    cache.getIfPresent(a_a.accessPath) should be(Some(a_a))
-    all_a.tail.foreach { r => cache.getIfPresent(r.accessPath) should be(Some(r))}
-    all_but_a.foreach { r => cache.getIfPresent(r.accessPath) should be(Some(r))}
+  def newResettableHierarchicalTableCache(table: Table, metrics: CacheMetrics, expireMs: Long, maximumSize: Int) = {
+    new ResettableHierarchicalTableCache(table, metrics, expireMs, maximumSize)
   }
 
-  it should "invalidate should invalidate children" in new CacheSetup {
-    val cache = new HierarchicalTableCache(table1, new CacheMetrics {}, 1000, 200)
+  def tableCacheBehavior(createCache: (Table, CacheMetrics, Long, Int) => TableCache[Record]) {
+    it should "cache all values" in new CacheSetup {
+      val cache = createCache(table1, new CacheMetrics {}, 1000, 200)
 
-    // Cache all records and verify their presence/value
-    all.foreach { r => cache.getIfPresent(r.accessPath) should be(None)}
-    all.foreach(r => cache.put(r.accessPath, r))
-    all.foreach { r => cache.getIfPresent(r.accessPath) should be(Some(r))}
+      // Cache all records and verify their presence/value
+      all.foreach(r => cache.getIfPresent(r.accessPath) should be(None))
+      all.foreach(r => cache.put(r.accessPath, r))
+      all.foreach(r => cache.getIfPresent(r.accessPath) should be(Some(r)))
 
-    // Invalidate a leaf and verify not cached anymore
-    cache.getIfPresent(c.accessPath) should be(Some(c))
-    cache.invalidate(c.accessPath)
-    cache.getIfPresent(c.accessPath) should be(None)
-    val all_not_c = withoutAncestor(all, "c")
-    all_not_c.foreach { r => cache.getIfPresent(r.accessPath) should be(Some(r))}
+      // Update one leaf value and verify cache is updated
+      cache.getIfPresent(b_a_a.accessPath) should be(Some(b_a_a))
+      val b_a_a2 = record(b_a_a.table, b_a_a.accessPath, "2")
+      cache.put(b_a_a2.accessPath, b_a_a2)
+      cache.getIfPresent(b_a_a.accessPath) should be(Some(b_a_a2))
+    }
 
-    // Invalidate a parent and verify itself/children not cached anymore
-    cache.getIfPresent(a.accessPath) should be(Some(a))
-    cache.invalidate(a.accessPath)
-    all_a.foreach { r => cache.getIfPresent(r.accessPath) should be(None)}
-    val all_not_c_and_a = withoutAncestor(all_not_c, "a")
-    all_not_c_and_a.foreach { r => cache.getIfPresent(r.accessPath) should be(Some(r))}
+    it should "update should NOT invalidate children" in new CacheSetup {
+      val cache = createCache(table1, new CacheMetrics {}, 1000, 200)
+
+      // Cache all records and verify their presence/value
+      all.foreach(r => cache.getIfPresent(r.accessPath) should be(None))
+      all.foreach(r => cache.put(r.accessPath, r))
+      all.foreach(r => cache.getIfPresent(r.accessPath) should be(Some(r)))
+
+      // Update one value and verify cache is updated and children NOT invalidated
+      cache.getIfPresent(a.accessPath) should be(Some(a))
+      val a2 = record(a.table, a.accessPath, "2")
+      cache.put(a2.accessPath, a2)
+      cache.getIfPresent(a.accessPath) should be(Some(a2))
+      cache.getIfPresent(a_a.accessPath) should be(Some(a_a))
+      all_a.tail.foreach(r => cache.getIfPresent(r.accessPath) should be(Some(r)))
+      all_but_a.foreach(r => cache.getIfPresent(r.accessPath) should be(Some(r)))
+    }
+
+    it should "invalidate should invalidate children" in new CacheSetup {
+      val cache = createCache(table1, new CacheMetrics {}, 1000, 200)
+
+      // Cache all records and verify their presence/value
+      all.foreach(r => cache.getIfPresent(r.accessPath) should be(None))
+      all.foreach(r => cache.put(r.accessPath, r))
+      all.foreach(r => cache.getIfPresent(r.accessPath) should be(Some(r)))
+
+      // Invalidate a leaf and verify not cached anymore
+      cache.getIfPresent(c.accessPath) should be(Some(c))
+      cache.invalidate(c.accessPath)
+      cache.getIfPresent(c.accessPath) should be(None)
+      val all_not_c = withoutAncestor(all, "c")
+      all_not_c.foreach(r => cache.getIfPresent(r.accessPath) should be(Some(r)))
+
+      // Invalidate a parent and verify itself/children not cached anymore
+      cache.getIfPresent(a.accessPath) should be(Some(a))
+      cache.invalidate(a.accessPath)
+      all_a.foreach(r => cache.getIfPresent(r.accessPath) should be(None))
+      val all_not_c_and_a = withoutAncestor(all_not_c, "a")
+      all_not_c_and_a.foreach(r => cache.getIfPresent(r.accessPath) should be(Some(r)))
+    }
+
+    it should "evict least recently used record when reaching max cache size" in new CacheSetup {
+      val maximumSize = all_a.size
+      val cache = createCache(table1, new CacheMetrics {}, 1000, maximumSize)
+
+      all_a.foreach(r => cache.getIfPresent(r.accessPath) should be(None))
+      all_a.foreach(r => cache.put(r.accessPath, r))
+      all_a.foreach(r => cache.getIfPresent(r.accessPath) should be(Some(r)))
+      all_but_a.foreach(r => cache.getIfPresent(r.accessPath) should be(None))
+
+      // Add an extra record, the first record should be evicted. Note that even if the evicted record has children
+      // in the cache, the children are not evicted.
+      cache.put(c.accessPath, c)
+      cache.getIfPresent(c.accessPath) should be(Some(c))
+      cache.getIfPresent(all_a.head.accessPath) should be(None)
+      all_a.head should be(a)
+
+      val other_a = all_a.filterNot(_.accessPath == all_a.head.accessPath)
+      other_a.foreach(r => cache.getIfPresent(r.accessPath) should be(Some(r)))
+    }
+
+    it should "evict records after expiration" in new CacheSetup with Eventually {
+      val expireMs = 25
+      val cache = createCache(table1, new CacheMetrics {}, expireMs, 200)
+      implicit override val patienceConfig =
+        PatienceConfig(timeout = scaled(Span(2, Seconds)), interval = scaled(Span(30, Millis)))
+
+      all.foreach(r => cache.getIfPresent(r.accessPath) should be(None))
+      all.foreach(r => cache.put(r.accessPath, r))
+      all.exists(r => cache.getIfPresent(r.accessPath) == Some(r))
+
+      eventually {
+        all.foreach(r => cache.getIfPresent(r.accessPath) should be(None))
+      }
+    }
   }
 
-  it should "evict least recently used record when reaching max cache size" in new CacheSetup {
-    val cache = new HierarchicalTableCache(table1, new CacheMetrics {}, 1000, maximumSize = all_a.size)
+  def resettableTableCacheBehavior(createCache: (Table, CacheMetrics, Long, Int) => ResettableTableCache[Record]) {
+    it should "invalidate all values" in new CacheSetup {
+      val metrics = new CacheMetrics {}
+      val cache = createCache(table1, metrics, 1000, 200)
 
-    all_a.foreach { r => cache.getIfPresent(r.accessPath) should be(None)}
-    all_a.foreach(r => cache.put(r.accessPath, r))
-    all_a.foreach { r => cache.getIfPresent(r.accessPath) should be(Some(r))}
-    all_but_a.foreach { r => cache.getIfPresent(r.accessPath) should be(None)}
+      // Cache all records and verify their presence/value
+      all.foreach(r => cache.getIfPresent(r.accessPath) should be(None))
+      metrics.cacheCurrentSizeGauge.get("total").get.value() should be(0)
+      all.foreach(r => cache.put(r.accessPath, r))
+      all.foreach(r => cache.getIfPresent(r.accessPath) should be(Some(r)))
+      metrics.cacheCurrentSizeGauge.get("total").get.value() should be(all.size)
 
-    // Add an extra record, the first record should be evicted. Note that even if the evicted record has children
-    // in the cache, the children are not evicted.
-    cache.put(c.accessPath, c)
-    cache.getIfPresent(c.accessPath) should be(Some(c))
-    cache.getIfPresent(all_a.head.accessPath) should be(None)
-    all_a.head should be(a)
-
-    val other_a = all_a.filterNot(_.accessPath == all_a.head.accessPath)
-    other_a.foreach { r => cache.getIfPresent(r.accessPath) should be(Some(r))}
-  }
-
-  it should "evict records after expiration" in new CacheSetup with Eventually {
-    val cache = new HierarchicalTableCache(table1, new CacheMetrics {}, expireMs = 25, 200)
-    implicit override val patienceConfig =
-      PatienceConfig(timeout = scaled(Span(2, Seconds)), interval = scaled(Span(30, Millis)))
-
-    all.foreach { r => cache.getIfPresent(r.accessPath) should be(None)}
-    all.foreach(r => cache.put(r.accessPath, r))
-    all.exists(r => cache.getIfPresent(r.accessPath) == Some(r))
-
-    eventually {
-      all.foreach { r => cache.getIfPresent(r.accessPath) should be(None)}
+      // Reset cache and verify it contanis no more values
+      cache.invalidateAll()
+      all.foreach(r => cache.getIfPresent(r.accessPath) should be(None))
+      metrics.cacheCurrentSizeGauge.get("total").get.value() should be(0)
     }
   }
 }


### PR DESCRIPTION
Also implement cache reset i.e. `invalidateAll()` invoked by `ConsistencyMasterSlave` when the service member goes down. 

TO BE MERGE IN #159
